### PR TITLE
MAM-170: Raise api max limit

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -499,3 +499,5 @@ RSpec/Rails/HttpStatus:
   Enabled: false
 RSpec/StubbedMock:
   Enabled: false
+RSpec/LeakyConstantDeclaration:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -495,3 +495,7 @@ RSpec/DescribeClass:
   Enabled: false
 RSpec/LetSetup:
   Enabled: false
+RSpec/Rails/HttpStatus:
+  Enabled: false
+RSpec/StubbedMock:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -501,3 +501,7 @@ RSpec/StubbedMock:
   Enabled: false
 RSpec/LeakyConstantDeclaration:
   Enabled: false
+Lint/ConstantDefinitionInBlock:
+  Enabled: false
+Lint/EmptyClass:
+  Enabled: false

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -2,6 +2,7 @@
 
 class Api::BaseController < ApplicationController
   DEFAULT_STATUSES_LIMIT = 20
+  MAX_LIMIT = 500
   DEFAULT_ACCOUNTS_LIMIT = 40
 
   include RateLimitHeaders
@@ -101,7 +102,7 @@ class Api::BaseController < ApplicationController
   def limit_param(default_limit)
     return default_limit unless params[:limit]
 
-    [params[:limit].to_i.abs, default_limit * 2].min
+    [params[:limit].to_i.abs, MAX_LIMIT].min
   end
 
   def params_slice(*keys)

--- a/spec/controllers/api/base_controller_spec.rb
+++ b/spec/controllers/api/base_controller_spec.rb
@@ -89,4 +89,11 @@ describe Api::BaseController do
       end
     end
   end
+
+  describe '#limit_param' do
+    it "doesn't return more than the max limit" do
+      allow(controller).to receive(:params).and_return({ limit: 1000 })
+      expect(controller.send(:limit_param, 20)).to eq(Api::BaseController::MAX_LIMIT)
+    end
+  end
 end


### PR DESCRIPTION
After talking with @ShihabM it seems like the most useful solution is to raise the max limit to 500, pending his final decision.  This lets him set the limit himself via parameter, and also prevents people trying to pull like 10K statuses and crashing the server or whatever.

To be reviewed but not merged until @ShihabM gives the OK.