### PR TITLE
explictly set datadog service names

### DIFF
--- a/config/initializers/datadog-tracer.rb
+++ b/config/initializers/datadog-tracer.rb
@@ -4,5 +4,9 @@ if Rails.env.production? || Rails.env.staging?
   Datadog.configure do |c|
     c.env = Rails.env
     c.service = 'moth.social'
+    c.tracing.instrument :httprb, service_name: 'moth.social'
+    c.tracing.instrument :faraday, service_name: 'moth.social'
+    c.tracing.instrument :active_support, service_name: 'moth.social'
+    c.tracing.instrument :http, service_name: 'moth.social'
   end
 end

--- a/config/initializers/datadog-tracer.rb
+++ b/config/initializers/datadog-tracer.rb
@@ -2,7 +2,11 @@ require 'ddtrace'
 
 if Rails.env.production? || Rails.env.staging?
   Datadog.configure do |c|
-    c.env = Rails.env
+    if Rails.configuration.hosts[0].include? 'staging'
+      c.env = 'staging'
+    else
+      c.env = Rails.env
+    end
     c.service = 'moth.social'
     c.tracing.instrument :httprb, service_name: 'moth.social'
     c.tracing.instrument :faraday, service_name: 'moth.social'


### PR DESCRIPTION
Ideally, we have one service name in dd for each entrypoint - so moth.social, sidekiq, etc.  For historical reasons, certain trace instruments were given their own service name anyway, so we have to override them manually in order to see them grouped together appropriately on dd.

For the definition of "service": https://github.com/DataDog/dd-trace-rb/issues/2518#issuecomment-1376390455 and https://github.com/DataDog/dd-trace-rb/issues/2347#issuecomment-1301944164

for manually setting service_name: https://github.com/DataDog/dd-trace-rb/issues/2347#issuecomment-1325715145