### PR TITLE
Bugfix: trends update scheduler

### DIFF
--- a/app/workers/scheduler/trends/trends_update_scheduler.rb
+++ b/app/workers/scheduler/trends/trends_update_scheduler.rb
@@ -86,7 +86,7 @@ class Scheduler::Trends::TrendsUpdateScheduler
         card = PreviewCard.find_by(url: link['url'])
         next unless card
         max_score = calculate_max_score(link['history'])
-        if max_score >= card.max_score
+        if max_score >= card.max_score.to_i
           card.update(max_score: max_score, max_score_at: Time.now.utc)
         end
       end

--- a/spec/workers/scheduler/trends/trends_update_scheduler_spec.rb
+++ b/spec/workers/scheduler/trends/trends_update_scheduler_spec.rb
@@ -61,4 +61,20 @@ describe Scheduler::Trends::TrendsUpdateScheduler do
       end
     end
   end
+
+  describe '#get_links' do
+    before do
+      stub_request(:get, url).to_return(status: 200,
+                                        body: links.to_json,
+                                        headers: {})
+    end
+
+    let(:url) { 'https://example.com' }
+    let(:card) { Fabricate(:preview_card, url: url, max_score: nil) }
+    let(:links) { [REST::PreviewCardSerializer.new(card).as_json.merge({history: []})] }
+
+    it 'handles a missing max_score' do
+      expect { subject.get_links(url) }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
Some preview cards don't have a max score at all.  This assigns them an initial max_score of 0.