### PR TITLE
onboarding: Remove check for account discoverable in suggestions

### DIFF
--- a/app/controllers/api/v2/onboarding_follow_recommendations_controller.rb
+++ b/app/controllers/api/v2/onboarding_follow_recommendations_controller.rb
@@ -21,7 +21,7 @@ class Api::V2::OnboardingFollowRecommendationsController < Api::BaseController
         items: category['items'].filter_map do |item|
           if item['type'] == 'account'
             account = find_account(item)
-            next if account.nil? || !account.discoverable?
+            next if account.nil?
             { name: account,
               type: :account,
               summary: item['summary'] }


### PR DESCRIPTION
As we've secured permission for all the suggested follows currently in the YAML, we should be able to present them, even though some accounts have 'discoverable' set to false on Mastodon.