### PR TITLE
add rebuild param

### DIFF
--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Layout/LineLength
 class Api::V1::AccountsController < Api::BaseController
   before_action -> { authorize_if_got_token! :read, :'read:accounts' }, except: [:create, :follow, :unfollow, :remove_from_followers, :block, :unblock, :mute, :unmute]
   before_action -> { doorkeeper_authorize! :follow, :write, :'write:follows' }, only: [:follow, :unfollow, :remove_from_followers]
@@ -113,3 +114,4 @@ class Api::V1::AccountsController < Api::BaseController
     ENV['OMNIAUTH_ONLY'] == 'true'
   end
 end
+# rubocop:enable Layout/LineLength

--- a/app/controllers/api/v1/tags_controller.rb
+++ b/app/controllers/api/v1/tags_controller.rb
@@ -21,6 +21,9 @@ class Api::V1::TagsController < Api::BaseController
 
   def unfollow
     TagFollow.find_by(account: current_account, tag: @tag)&.destroy!
+    if params[:rebuild]
+      RegenerationWorker.perform_async(current_account.id)
+    end
     render json: @tag, serializer: REST::TagSerializer
   end
 

--- a/app/controllers/api/v1/tags_controller.rb
+++ b/app/controllers/api/v1/tags_controller.rb
@@ -13,6 +13,9 @@ class Api::V1::TagsController < Api::BaseController
 
   def follow
     TagFollow.create_with(rate_limit: true).find_or_create_by!(tag: @tag, account: current_account)
+    if params[:rebuild]
+      RegenerationWorker.perform_async(current_account.id)
+    end
     render json: @tag, serializer: REST::TagSerializer
   end
 

--- a/spec/controllers/api/v1/accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts_controller_spec.rb
@@ -1,4 +1,7 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
+# rubocop:disable all
 
 RSpec.describe Api::V1::AccountsController, type: :controller do
   render_views
@@ -368,3 +371,5 @@ RSpec.describe Api::V1::AccountsController, type: :controller do
     it_behaves_like 'forbidden for wrong scope', 'read:accounts'
   end
 end
+
+#rubocop:enable all

--- a/spec/controllers/api/v1/accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts_controller_spec.rb
@@ -70,10 +70,12 @@ RSpec.describe Api::V1::AccountsController, type: :controller do
   describe 'POST #follow' do
     let(:scopes) { 'write:follows' }
     let(:other_account) { Fabricate(:account, username: 'bob', locked: locked) }
+    let!(:params) { { id: other_account.id } }
 
     context do
       before do
-        post :follow, params: { id: other_account.id }
+        allow(RegenerationWorker).to receive(:perform_async)
+        post :follow, params: params
       end
 
       context 'with unlocked account' do
@@ -116,6 +118,15 @@ RSpec.describe Api::V1::AccountsController, type: :controller do
         end
 
         it_behaves_like 'forbidden for wrong scope', 'read:accounts'
+      end
+
+      context 'with rebuild param' do
+        let!(:params) { super().merge(rebuild: true) }
+        let!(:locked) { false }
+
+        it 'rebuilds if necessary' do
+          expect(RegenerationWorker).to have_received(:perform_async)
+        end
       end
     end
 
@@ -162,10 +173,12 @@ RSpec.describe Api::V1::AccountsController, type: :controller do
   describe 'POST #unfollow' do
     let(:scopes) { 'write:follows' }
     let(:other_account) { Fabricate(:account, username: 'bob') }
+    let!(:params) {{ id: other_account.id }}
 
     before do
+      allow(RegenerationWorker).to receive(:perform_async)
       user.account.follow!(other_account)
-      post :unfollow, params: { id: other_account.id }
+      post :unfollow, params: params
     end
 
     it 'returns http success' do
@@ -177,6 +190,14 @@ RSpec.describe Api::V1::AccountsController, type: :controller do
     end
 
     it_behaves_like 'forbidden for wrong scope', 'read:accounts'
+
+    context 'with rebuild param' do
+      let!(:params) { super().merge(rebuild: true) }
+
+      it 'rebuilds if necessary' do
+          expect(RegenerationWorker).to have_received(:perform_async)
+      end
+    end
   end
 
   describe 'POST #remove_from_followers' do

--- a/spec/controllers/api/v1/tags_controller_spec.rb
+++ b/spec/controllers/api/v1/tags_controller_spec.rb
@@ -1,5 +1,7 @@
-require 'rails_helper'
+# frozen_string_literal: true
 
+require 'rails_helper'
+# rubocop:disable all
 RSpec.describe Api::V1::TagsController, type: :controller do
   render_views
 
@@ -67,33 +69,35 @@ RSpec.describe Api::V1::TagsController, type: :controller do
       end
     end
 
-  context 'with non-existing tag' do
-    let(:name) { 'hoge' }
+    context 'with non-existing tag' do
+      let(:name) { 'hoge' }
+
+      it 'returns http success' do
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'creates follow' do
+        expect(TagFollow.where(tag: Tag.find_by!(name: name), account: user.account).exists?).to be true
+      end
+    end
+  end
+
+  describe 'POST #unfollow' do
+    let!(:tag) { Fabricate(:tag, name: 'foo') }
+    let!(:tag_follow) { Fabricate(:tag_follow, account: user.account, tag: tag) }
+
+    before do
+      post :unfollow, params: { id: tag.name }
+    end
 
     it 'returns http success' do
       expect(response).to have_http_status(:success)
     end
 
-    it 'creates follow' do
-      expect(TagFollow.where(tag: Tag.find_by!(name: name), account: user.account).exists?).to be true
+    it 'removes the follow' do
+      expect(TagFollow.where(tag: tag, account: user.account).exists?).to be false
     end
   end
 end
 
-describe 'POST #unfollow' do
-  let!(:tag) { Fabricate(:tag, name: 'foo') }
-  let!(:tag_follow) { Fabricate(:tag_follow, account: user.account, tag: tag) }
-
-  before do
-    post :unfollow, params: { id: tag.name }
-  end
-
-  it 'returns http success' do
-    expect(response).to have_http_status(:success)
-  end
-
-  it 'removes the follow' do
-    expect(TagFollow.where(tag: tag, account: user.account).exists?).to be false
-  end
-end
-end
+# rubocop:enable all

--- a/spec/controllers/api/v1/timelines/tag_controller_spec.rb
+++ b/spec/controllers/api/v1/timelines/tag_controller_spec.rb
@@ -30,12 +30,6 @@ describe Api::V1::Timelines::TagController do
       before do
         PostStatusService.new.call(user.account, text: 'It is a #test')
       end
-
-      it 'rebuilds if necessary' do
-        get :follow, params: { id: 1, rebuild: true }
-        expect(response).to have_http_status(200)
-        expect(RegenerationWorker).to receive(:perform_async)
-      end
     end
   end
 

--- a/spec/controllers/api/v1/timelines/tag_controller_spec.rb
+++ b/spec/controllers/api/v1/timelines/tag_controller_spec.rb
@@ -32,7 +32,7 @@ describe Api::V1::Timelines::TagController do
       end
 
       it 'rebuilds if necessary' do
-        get :follow, params: { id: 1, rebuild: true}
+        get :follow, params: { id: 1, rebuild: true }
         expect(response).to have_http_status(200)
         expect(RegenerationWorker).to receive(:perform_async)
       end

--- a/spec/controllers/api/v1/timelines/tag_controller_spec.rb
+++ b/spec/controllers/api/v1/timelines/tag_controller_spec.rb
@@ -25,6 +25,18 @@ describe Api::V1::Timelines::TagController do
         expect(response.headers['Link'].links.size).to eq(2)
       end
     end
+
+    describe 'GET #follow' do
+      before do
+        PostStatusService.new.call(user.account, text: 'It is a #test')
+      end
+
+      it 'rebuilds if necessary' do
+        get :follow, params: { id: 1, rebuild: true}
+        expect(response).to have_http_status(200)
+        expect(RegenerationWorker).to receive(:perform_async)
+      end
+    end
   end
 
   context 'without a user context' do


### PR DESCRIPTION
When we offer a number of follow options in onboarding, we want all of them to end up in the user's home feed.  So we'll add a parameter to rebuild the feed after every follow.

Right now, just as a POC, this is only implemented for tags.