### PR TITLE
feat: improve custom css for dark and light mode

### DIFF
--- a/public/custom.css
+++ b/public/custom.css
@@ -1,4 +1,6 @@
-/* Globals */
+/***********************************
+* GLOBALS
+***********************************/
 
 :root {
   --dark: #000;
@@ -12,6 +14,206 @@
   --color-2: #d72fd6;
   --color-3: #f6ca45;
 }
+
+/***********************************
+* DARK THEME (DEFAULT)
+***********************************/
+
+/* Layout */
+
+.theme-default ::-webkit-scrollbar-thumb {
+  background: var(--light-dark);
+}
+
+.theme-default .ui {
+  background: var(--dark);
+}
+
+.theme-default .empty-column-indicator {
+  background: var(--medium-dark);
+}
+
+.theme-default .compose-form {
+  background: var(--medium-dark);
+}
+
+.theme-default .item-list {
+  background: var(--medium-dark);
+}
+
+.theme-default .drawer__header {
+  background: var(--light-dark);
+}
+
+.theme-default .navigation-bar {
+  background: var(--medium-dark);
+}
+
+.theme-default .search__input {
+  background: var(--light-dark);
+  color: var(--medium-dark);
+}
+
+.theme-default .column-header,
+.theme-default .column-header__button {
+  background: var(--light-dark);
+  color: white;
+}
+
+.theme-default .column-header__button.active,
+.theme-default .column-header__button.active:hover,
+.theme-default .column-header__button:hover {
+  background: var(--light-dark);
+  color: var(--light);
+}
+
+.theme-default .dismissable-banner {
+  background: var(--medium-dark);
+  border-bottom: 1px solid var(--light-dark);
+}
+
+.theme-default .column-header__collapsible-inner {
+  background: var(--light-dark);
+}
+
+.theme-default .column-header__collapsible__extra {
+  color: var(--light);
+}
+
+.theme-default .column-settings__section {
+  color: var(--light);
+}
+
+.theme-default .status {
+  border-bottom: 4px solid var(--dark);
+}
+
+.theme-default .column-link--transparent  {
+  background: var(--medium-dark);
+  color: var(--light);
+}
+
+.theme-default .column-link--transparent:hover {
+  color: var(--light);
+}
+
+.theme-default .column-link--transparent:focus,
+.theme-default .column-link--transparent:hover {
+  background: none;
+  color: var(--accent);
+}
+
+.theme-default .column-link--transparent.active {
+  color: var(--light);
+  background: var(--accent);
+}
+
+.theme-default .column-header__back-button {
+  background: var(--light-dark);
+  color: var(--light);
+}
+
+.theme-default .column-inline-form {
+  background: var(--light-dark);
+}
+
+.theme-default .navigation-bar__profile a {
+  color: var(--light);
+}
+
+.theme-default .getting-started__wrapper {
+  background: var(--medium-dark);
+}
+
+.theme-default .account__header__bar .avatar .account__avatar {
+  background: var(--medium-dark);
+  border: 2px solid var(--medium-dark);
+}
+
+.theme-default .reply-indicator {
+  background: var(--light-dark);
+}
+
+.theme-default .reply-indicator__display-name {
+  color: var(--light);
+}
+
+/* Account */
+
+.theme-default .account__section-headline a.active,
+.theme-default .account__section-headline button.active,
+.theme-default .notification__filter-bar a.active,
+.theme-default .notification__filter-bar button.active {
+  background: var(--accent);
+  color: var(--light);
+}
+
+.theme-default .account__section-headline a,
+.theme-default .account__section-headline button,
+.theme-default .notification__filter-bar a,
+.theme-default .notification__filter-bar button {
+  background: var(--light-dark);
+  color: var(--dark-light);
+}
+
+.theme-default .account__section-headline a:hover,
+.theme-default .account__section-headline button:hover,
+.theme-default .notification__filter-bar a:hover,
+.theme-default .notification__filter-bar button:hover {
+  color: var(--light);
+}
+
+.theme-default .account__section-headline a.active::after,
+.theme-default .account__section-headline button.active::after,
+.theme-default .notification__filter-bar a.active::after,
+.theme-default .notification__filter-bar button.active::after {
+  border-color: transparent transparent var(--medium-dark);
+}
+
+.theme-default .account__section-headline a.active::after,
+.theme-default .account__section-headline a.active::before,
+.theme-default .account__section-headline button.active::after,
+.theme-default .account__section-headline button.active::before,
+.theme-default .notification__filter-bar a.active::after,
+.theme-default .notification__filter-bar a.active::before,
+.theme-default .notification__filter-bar button.active::after,
+.theme-default .notification__filter-bar button.active::before {
+  border-color: transparent transparent var(--medium-dark);
+}
+
+/* Posts */
+
+.theme-default .status__prepend {
+  color: var(--light);
+}
+
+.theme-default .status__prepend .status__display-name strong {
+  color: var(--light);
+}
+
+/* Admin */
+.theme-default body.admin {
+  background: var(--dark);
+}
+
+.theme-default .admin-wrapper .sidebar-wrapper__inner {
+  background: var(--medium-dark);
+}
+
+.theme-default .admin-wrapper .content__heading__tabs a.selected,
+.admin-wrapper .content__heading__tabs a.selected:hover {
+  background: var(--accent);
+}
+
+.theme-default .fa-close::before,
+.theme-default .fa-remove::before,
+.theme-default .fa-times::before {
+  color: var(--light);
+}
+
+/***********************************
+* UNIVERSAL
+***********************************/
 
 .button,
 .button.logo-button {
@@ -77,20 +279,8 @@ a.mention {
 
 /* Layout */
 
-::-webkit-scrollbar-thumb {
-  background: var(--light-dark);
-}
-
-.ui {
-  background: var(--dark);
-}
-
 .column > .scrollable {
   background: none;
-}
-
-.empty-column-indicator {
-  background: var(--medium-dark);
 }
 
 .empty-column-indicator span {
@@ -106,14 +296,6 @@ a.mention {
   color: var(--accent);
 }
 
-.item-list {
-  background: var(--medium-dark);
-}
-
-.drawer__header {
-  background: var(--light-dark);
-}
-
 .drawer__header a:hover {
   background: var(--accent);
 }
@@ -122,17 +304,6 @@ a.mention {
   color: var(--light);
 }
 
-.compose-form {
-  background: var(--medium-dark);
-}
-
-.reply-indicator {
-  background: var(--light-dark);
-}
-
-.reply-indicator__display-name {
-  color: var(--light);
-}
 
 .display-name__account {
   color: var(--dark-light);
@@ -146,31 +317,6 @@ a.mention {
 
 .drawer__inner__mastodon img {
   display: none;
-}
-
-.column-header,
-.column-header__button {
-  background: var(--light-dark);
-  color: white;
-}
-
-.column-header__button.active,
-.column-header__button.active:hover,
-.column-header__button:hover {
-  background: var(--light-dark);
-  color: var(--light);
-}
-
-.column-header__collapsible-inner {
-  background: var(--light-dark);
-}
-
-.column-header__collapsible__extra {
-  color: var(--light);
-}
-
-.column-settings__section {
-  color: var(--light);
 }
 
 .column-back-button {
@@ -194,22 +340,6 @@ a.mention {
   border-color: var(--accent);
 }
 
-.dismissable-banner {
-  background: var(--medium-dark);
-  border-bottom: 1px solid var(--light-dark);
-}
-
-.fa-close::before,
-.fa-remove::before,
-.fa-times::before {
-  color: var(--light);
-}
-
-.search__input {
-  background: var(--light-dark);
-  color: var(--medium-dark);
-}
-
 .search__input:focus {
   background: var(--light);
 }
@@ -218,34 +348,8 @@ a.mention {
   color: var(--dark-light);
 }
 
-.navigation-bar {
-  background: var(--medium-dark);
-}
-
 .navigation-bar a {
   color: var(--dark-light);
-}
-
-.status {
-  border-bottom: 4px solid var(--dark);
-}
-
-.column-header__back-button {
-  background: var(--light-dark);
-  color: var(--light);
-}
-
-.column-inline-form {
-  background: var(--light-dark);
-}
-
-.getting-started__wrapper {
-  background: var(--medium-dark);
-}
-
-.account__header__bar .avatar .account__avatar {
-  background: var(--medium-dark);
-  border: 2px solid var(--medium-dark);
 }
 
 .text-btn {
@@ -270,10 +374,6 @@ a.mention {
 }
 
 /* Account */
-
-.navigation-bar__profile a {
-  color: var(--light);
-}
 
 .account__header {
   background: var(--light-dark);
@@ -374,7 +474,7 @@ a.mention {
 }
 
 .navigation-panel__logo {
-  padding: 1rem 1rem 0 1rem;
+  padding: 1rem 1rem 0;
 }
 
 .navigation-panel__logo hr {
@@ -386,7 +486,8 @@ a.mention {
 }
 
 .navigation-panel__logo a,
-.navigation-panel__logo a:hover {
+.navigation-panel__logo a:hover,
+.navigation-panel__logo a:focus {
   margin-bottom: 0.75rem;
   width: 3rem;
   height: 3rem;
@@ -396,31 +497,6 @@ a.mention {
   background-size: 100% auto;
 }
 
-.column-link {
-  background: var(--medium-dark);
-  color: var(--light);
-}
-
-.column-link--transparent {
-  color: var(--medium-light);
-}
-
-.column-link--transparent:hover {
-  color: var(--light);
-}
-
-.column-link:active,
-.column-link:focus,
-.column-link:hover {
-  background: none;
-  color: var(--accent);
-}
-
-.column-link--transparent.active {
-  color: var(--light);
-  background: var(--accent);
-}
-
 .icon-with-badge__badge {
   background: var(--accent);
   border: 2px solid var(--dark);
@@ -428,11 +504,11 @@ a.mention {
 
 .column-header.active .column-header__icon {
   color: var(--accent);
-  text-shadow: 0 0 10px rgb( 244 88 0 / 40%);
+  text-shadow: 0 0 10px rgb(244 88 0 / 40%);
 }
 
 .column-header__wrapper.active {
-  box-shadow: 0 1px 0 rgb( 0 0 0 / 100%);
+  box-shadow: 0 1px 0 rgb(0 0 0 / 100%);
 }
 
 .column-header__wrapper.active::before {
@@ -483,47 +559,6 @@ button.icon-button i.fa-retweet:hover {
   color: var(--light);
 }
 
-.account__section-headline a.active,
-.account__section-headline button.active,
-.notification__filter-bar a.active,
-.notification__filter-bar button.active {
-  background: var(--accent);
-  color: var(--light);
-}
-
-.account__section-headline a.active::after,
-.account__section-headline button.active::after,
-.notification__filter-bar a.active::after,
-.notification__filter-bar button.active::after {
-  border-color: transparent transparent var(--medium-dark);
-}
-
-.account__section-headline a.active::after,
-.account__section-headline a.active::before,
-.account__section-headline button.active::after,
-.account__section-headline button.active::before,
-.notification__filter-bar a.active::after,
-.notification__filter-bar a.active::before,
-.notification__filter-bar button.active::after,
-.notification__filter-bar button.active::before {
-  border-color: transparent transparent var(--medium-dark);
-}
-
-.account__section-headline a,
-.account__section-headline button,
-.notification__filter-bar a,
-.notification__filter-bar button {
-  background: var(--light-dark);
-  color: var(--dark-light);
-}
-
-.account__section-headline a:hover,
-.account__section-headline button:hover,
-.notification__filter-bar a:hover,
-.notification__filter-bar button:hover {
-  color: var(--light);
-}
-
 .account__section-headline,
 .notification__filter-bar {
   border-bottom: none;
@@ -541,14 +576,6 @@ button.icon-button i.fa-retweet:hover {
 .icon-button.star-icon.active,
 .notification__favourite-icon-wrapper .star-icon {
   color: var(--color-3);
-}
-
-.status__prepend {
-  color: var(--light);
-}
-
-.status__prepend .status__display-name strong {
-  color: var(--light);
 }
 
 .notification__message .fa {
@@ -625,19 +652,6 @@ a.status-card.compact:hover {
 }
 
 /* Admin */
-
-body.admin {
-  background: var(--dark);
-}
-
-.admin-wrapper .sidebar-wrapper__inner {
-  background: var(--medium-dark);
-}
-
-.admin-wrapper .content__heading__tabs a.selected,
-.admin-wrapper .content__heading__tabs a.selected:hover {
-  background: var(--accent);
-}
 
 .admin-wrapper p a {
   color: var(--light) !important;

--- a/public/custom.css
+++ b/public/custom.css
@@ -138,7 +138,20 @@
   color: var(--light);
 }
 
+.theme-default .load-more {
+  color: var(--light);
+}
+
+.theme-default .load-more:hover {
+  background: var(--medium-dark);
+  color: var(--accent);
+}
+
 /* Account */
+
+.theme-default .account {
+  border-bottom: 4px solid var(--dark);
+}
 
 .theme-default .account__section-headline a.active,
 .theme-default .account__section-headline button.active,
@@ -181,6 +194,18 @@
   border-color: transparent transparent var(--medium-dark);
 }
 
+.theme-default a.mention {
+  color: var(--light) !important;
+}
+
+.theme-default .notification__message {
+  color: var(--light);
+}
+
+.theme-default .notification__message .fa {
+  color: var(--light) !important;
+}
+
 /* Posts */
 
 .theme-default .status__prepend {
@@ -209,6 +234,19 @@
 .theme-default .fa-remove::before,
 .theme-default .fa-times::before {
   color: var(--light);
+}
+
+/***********************************
+* LIGHT THEME
+***********************************/
+
+/* Layout */
+.theme-mastodon-light .column-link--transparent.active {
+  color: var(--accent);
+}
+
+.theme-mastodon-light .notification__message .fa {
+  color: var(--dark) !important;
 }
 
 /***********************************
@@ -274,10 +312,6 @@ p a {
   color: var(--dark-light) !important;
 }
 
-a.mention {
-  color: var(--light) !important;
-}
-
 /* Layout */
 
 .column > .scrollable {
@@ -286,15 +320,6 @@ a.mention {
 
 .empty-column-indicator span {
   color: var(--dark-light);
-}
-
-.load-more {
-  color: var(--light);
-}
-
-.load-more:hover {
-  background: var(--medium-dark);
-  color: var(--accent);
 }
 
 .drawer__header a:hover {
@@ -453,10 +478,6 @@ a.mention {
   border-bottom: none;
 }
 
-.account {
-  border-bottom: 4px solid var(--dark);
-}
-
 .account__header__bio .account__header__fields a {
   color: var(--accent);
 }
@@ -564,10 +585,6 @@ button.icon-button i.fa-retweet:hover {
   border-bottom: none;
 }
 
-.notification__message {
-  color: var(--light);
-}
-
 .notification.unread::before,
 .status__wrapper.unread::before {
   border-left: 2px solid var(--accent);
@@ -576,10 +593,6 @@ button.icon-button i.fa-retweet:hover {
 .icon-button.star-icon.active,
 .notification__favourite-icon-wrapper .star-icon {
   color: var(--color-3);
-}
-
-.notification__message .fa {
-  color: var(--light) !important;
 }
 
 .poll__chart {

--- a/public/custom.css
+++ b/public/custom.css
@@ -106,7 +106,6 @@
   border-bottom: 10px solid var(--dark);
 }
 
-
 .theme-default .unhandled-link {
   color: var(--light) !important;
 }
@@ -451,6 +450,7 @@
   display: none;
 }
 
+.column-header__back-button,
 .column-back-button {
   color: var(--accent);
 }
@@ -566,22 +566,6 @@
   margin-top: 1.5rem;
 }
 
-.navigation-panel__logo a svg {
-  display: none;
-}
-
-.navigation-panel__logo a,
-.navigation-panel__logo a:hover,
-.navigation-panel__logo a:focus {
-  margin-bottom: 0.75rem;
-  width: 3rem;
-  height: 3rem;
-  background: none;
-  background-image: url('https://cdn.shopify.com/s/files/1/0614/6565/7577/files/mammoth-logo.svg');
-  background-repeat: no-repeat;
-  background-size: 100% auto;
-}
-
 .icon-with-badge__badge {
   background: var(--accent);
   border: 2px solid var(--dark);
@@ -684,7 +668,7 @@ button.icon-button i.fa-retweet:hover {
 }
 
 .unhandled-link {
-  color: var(--accent)!important;
+  color: var(--accent) !important;
 }
 
 .reply-indicator__content a,
@@ -704,7 +688,8 @@ button.icon-button i.fa-retweet:hover {
   background-color: rgb(63 143 245 / 20%);
 }
 
-.compose-form .compose-form__warning, .compose-form .compose-form__warning a {
+.compose-form .compose-form__warning,
+.compose-form .compose-form__warning a {
   color: var(--accent);
 }
 
@@ -718,17 +703,6 @@ button.icon-button i.fa-retweet:hover {
 
 .admin-wrapper .sidebar .logo {
   opacity: 0;
-}
-
-.admin-wrapper .sidebar > a:first-of-type {
-  display: flex;
-  width: 7rem;
-  height: 7rem;
-  background: none;
-  background-image: url('https://cdn.shopify.com/s/files/1/0614/6565/7577/files/mammoth-logo.svg');
-  background-repeat: no-repeat;
-  background-size: 100% auto;
-  margin: 30px auto 0;
 }
 
 .admin-wrapper p a {
@@ -803,4 +777,55 @@ button.icon-button i.fa-retweet:hover {
 .privacy-dropdown__option.active,
 .privacy-dropdown__option:hover {
   background: var(--accent);
+}
+
+
+/***********************************
+* REPLACE MASTODON DEFAULT LOGO
+***********************************/
+
+.navigation-panel__logo a svg {
+  display: none;
+}
+
+.navigation-panel__logo a,
+.navigation-panel__logo a:hover,
+.navigation-panel__logo a:focus {
+  margin-bottom: 0.75rem;
+  width: 3rem;
+  height: 3rem;
+  background: none;
+  background-image: url('https://cdn.shopify.com/s/files/1/0614/6565/7577/files/mammoth-logo.svg');
+  background-repeat: no-repeat;
+  background-size: 100% auto;
+}
+
+
+@media screen and (max-width: 1174px) {
+  .layout-single-column .ui__header__logo svg {
+    display: none;
+  }
+
+  .layout-single-column .ui__header__logo {
+    margin-left: 0.7rem;
+    width: 1rem;
+    height: 0.8rem;
+    background: none;
+    background-image: url('https://cdn.shopify.com/s/files/1/0614/6565/7577/files/mammoth-logo.svg');
+    background-repeat: no-repeat;
+    background-size: 100% auto;
+  }
+}
+
+/* Admin */
+
+.admin-wrapper .sidebar > a:first-of-type {
+  display: flex;
+  width: 7rem;
+  height: 7rem;
+  background: none;
+  background-image: url('https://cdn.shopify.com/s/files/1/0614/6565/7577/files/mammoth-logo.svg');
+  background-repeat: no-repeat;
+  background-size: 100% auto;
+  margin: 30px auto 0;
 }

--- a/public/custom.css
+++ b/public/custom.css
@@ -711,7 +711,7 @@ button.icon-button i.fa-retweet:hover {
   background: var(--accent);
 }
 
- .admin-wrapper p a {
+.admin-wrapper p a {
   color: var(--dark) !important;
 }
 

--- a/public/custom.css
+++ b/public/custom.css
@@ -3,14 +3,14 @@
 :root {
   --dark: #000;
   --medium-dark: #111111;
-  --light-dark: #2B2B2B;
-  --light: #FFF;
-  --medium-light: #C5C5C5;
+  --light-dark: #2b2b2b;
+  --light: #fff;
+  --medium-light: #c5c5c5;
   --dark-light: #858585;
   --light-accent: #539af7;
-  --accent: #3F8FF5;
-  --color-2: #D72FD6;
-  --color-3: #F6CA45;
+  --accent: #3f8ff5;
+  --color-2: #d72fd6;
+  --color-3: #f6ca45;
 }
 
 .button,
@@ -18,12 +18,17 @@
   background-color: var(--accent);
 }
 
-.button:active, .button:focus, .button:hover, .button.logo-button:hover {
+.button:active,
+.button:focus,
+.button:hover,
+.button.logo-button:hover {
   background-color: var(--light);
   color: var(--accent);
 }
 
-.button.logo-button.button--destructive:active, .button.logo-button.button--destructive:focus, .button.logo-button.button--destructive:hover {
+.button.logo-button.button--destructive:active,
+.button.logo-button.button--destructive:focus,
+.button.logo-button.button--destructive:hover {
   background: var(--accent);
   color: var(--light);
 }
@@ -56,7 +61,8 @@
   border: 0;
 }
 
-.button.disabled, .button:disabled {
+.button.disabled,
+.button:disabled {
   background-color: var(--dark-light);
   color: var(--medium-light);
 }
@@ -79,7 +85,7 @@ a.mention {
   background: var(--dark);
 }
 
-.column>.scrollable {
+.column > .scrollable {
   background: none;
 }
 
@@ -148,7 +154,9 @@ a.mention {
   color: white;
 }
 
-.column-header__button.active, .column-header__button.active:hover, .column-header__button:hover {
+.column-header__button.active,
+.column-header__button.active:hover,
+.column-header__button:hover {
   background: var(--light-dark);
   color: var(--light);
 }
@@ -191,7 +199,9 @@ a.mention {
   border-bottom: 1px solid var(--light-dark);
 }
 
-.fa-close:before, .fa-remove:before, .fa-times:before {
+.fa-close::before,
+.fa-remove::before,
+.fa-times::before {
   color: var(--light);
 }
 
@@ -296,7 +306,9 @@ a.mention {
   border: 1px solid var(--dark-light);
 }
 
-.icon-button:active, .icon-button:focus, .icon-button:hover {
+.icon-button:active,
+.icon-button:focus,
+.icon-button:hover {
   color: var(--light);
 }
 
@@ -349,7 +361,9 @@ a.mention {
   color: var(--accent);
 }
 
-.account__header__bio .account__header__fields .verified a, .account__header__bio .account__header__fields .verified dd, .account__header__bio .account__header__fields .verified dt {
+.account__header__bio .account__header__fields .verified a,
+.account__header__bio .account__header__fields .verified dd,
+.account__header__bio .account__header__fields .verified dt {
   color: var(--light);
 }
 
@@ -371,7 +385,7 @@ a.mention {
   display: none;
 }
 
-.navigation-panel__logo a, 
+.navigation-panel__logo a,
 .navigation-panel__logo a:hover {
   margin-bottom: 0.75rem;
   width: 3rem;
@@ -395,7 +409,9 @@ a.mention {
   color: var(--light);
 }
 
-.column-link:active, .column-link:focus, .column-link:hover {
+.column-link:active,
+.column-link:focus,
+.column-link:hover {
   background: none;
   color: var(--accent);
 }
@@ -419,7 +435,7 @@ a.mention {
   box-shadow: 0 1px 0 rgb( 0 0 0 / 100%);
 }
 
-.column-header__wrapper.active:before {
+.column-header__wrapper.active::before {
   background: none;
 }
 
@@ -460,34 +476,56 @@ button.icon-button i.fa-retweet:hover {
   background: none;
 }
 
-.muted .status__content, .muted .status__content a, .muted .status__content p, .muted .status__display-name strong {
+.muted .status__content,
+.muted .status__content a,
+.muted .status__content p,
+.muted .status__display-name strong {
   color: var(--light);
 }
 
-.account__section-headline a.active, .account__section-headline button.active, .notification__filter-bar a.active, .notification__filter-bar button.active {
+.account__section-headline a.active,
+.account__section-headline button.active,
+.notification__filter-bar a.active,
+.notification__filter-bar button.active {
   background: var(--accent);
   color: var(--light);
 }
 
-
-.account__section-headline a.active:after, .account__section-headline button.active:after, .notification__filter-bar a.active:after, .notification__filter-bar button.active:after {
+.account__section-headline a.active::after,
+.account__section-headline button.active::after,
+.notification__filter-bar a.active::after,
+.notification__filter-bar button.active::after {
   border-color: transparent transparent var(--medium-dark);
 }
 
-.account__section-headline a.active:after, .account__section-headline a.active:before, .account__section-headline button.active:after, .account__section-headline button.active:before, .notification__filter-bar a.active:after, .notification__filter-bar a.active:before, .notification__filter-bar button.active:after, .notification__filter-bar button.active:before {
+.account__section-headline a.active::after,
+.account__section-headline a.active::before,
+.account__section-headline button.active::after,
+.account__section-headline button.active::before,
+.notification__filter-bar a.active::after,
+.notification__filter-bar a.active::before,
+.notification__filter-bar button.active::after,
+.notification__filter-bar button.active::before {
   border-color: transparent transparent var(--medium-dark);
 }
 
-.account__section-headline a, .account__section-headline button, .notification__filter-bar a, .notification__filter-bar button {
+.account__section-headline a,
+.account__section-headline button,
+.notification__filter-bar a,
+.notification__filter-bar button {
   background: var(--light-dark);
   color: var(--dark-light);
 }
 
-.account__section-headline a:hover, .account__section-headline button:hover, .notification__filter-bar a:hover, .notification__filter-bar button:hover {
+.account__section-headline a:hover,
+.account__section-headline button:hover,
+.notification__filter-bar a:hover,
+.notification__filter-bar button:hover {
   color: var(--light);
 }
 
-.account__section-headline, .notification__filter-bar {
+.account__section-headline,
+.notification__filter-bar {
   border-bottom: none;
 }
 
@@ -495,11 +533,13 @@ button.icon-button i.fa-retweet:hover {
   color: var(--light);
 }
 
-.notification.unread:before, .status__wrapper.unread:before {
+.notification.unread::before,
+.status__wrapper.unread::before {
   border-left: 2px solid var(--accent);
 }
 
-.icon-button.star-icon.active, .notification__favourite-icon-wrapper .star-icon {
+.icon-button.star-icon.active,
+.notification__favourite-icon-wrapper .star-icon {
   color: var(--color-3);
 }
 
@@ -540,11 +580,13 @@ button.icon-button i.fa-retweet:hover {
   background: var(--accent);
 }
 
-.poll__input:active, .poll__input:focus, .poll__input:hover {
+.poll__input:active,
+.poll__input:focus,
+.poll__input:hover {
   border-color: var(--accent);
 }
 
-.poll__option input[type=text]:focus {
+.poll__option input[type="text"]:focus {
   border-color: var(--accent);
 }
 
@@ -570,7 +612,8 @@ a.status-card.compact:hover {
   background-color: var(--light-dark);
 }
 
-.reply-indicator__content .status__content__spoiler-link, .status__content .status__content__spoiler-link {
+.reply-indicator__content .status__content__spoiler-link,
+.status__content .status__content__spoiler-link {
   background: var(--light);
   color: var(--medium-dark);
 }
@@ -626,10 +669,10 @@ body.admin {
   color: var(--light);
 }
 
-.simple_form input[type=text]:active,
-.simple_form input[type=text]:focus,
-.simple_form input[type=password]:active,
-.simple_form input[type=password]:focus,
+.simple_form input[type="text"]:active,
+.simple_form input[type="text"]:focus,
+.simple_form input[type="password"]:active,
+.simple_form input[type="password"]:focus,
 .simple_form textarea:active,
 .simple_form textarea:focus {
   border-color: var(--accent);
@@ -657,7 +700,6 @@ body.admin {
   background-color: var(--light);
   color: var(--accent);
 }
-
 
 .privacy-dropdown.active .privacy-dropdown__value.active {
   background: var(--accent);

--- a/public/custom.css
+++ b/public/custom.css
@@ -88,7 +88,7 @@
   border-bottom: 4px solid var(--dark);
 }
 
-.theme-default .column-link--transparent  {
+.theme-default .column-link--transparent {
   background: var(--medium-dark);
   color: var(--light);
 }
@@ -269,7 +269,8 @@
   color: var(--medium-light);
 }
 
-p, p a {
+p,
+p a {
   color: var(--dark-light) !important;
 }
 
@@ -303,7 +304,6 @@ a.mention {
 .drawer__tab {
   color: var(--light);
 }
-
 
 .display-name__account {
   color: var(--dark-light);
@@ -652,6 +652,21 @@ a.status-card.compact:hover {
 }
 
 /* Admin */
+
+.admin-wrapper .sidebar .logo {
+  opacity: 0;
+}
+
+.admin-wrapper .sidebar > a:first-of-type {
+  display: flex;
+  width: 7rem;
+  height: 7rem;
+  background: none;
+  background-image: url('https://cdn.shopify.com/s/files/1/0614/6565/7577/files/mammoth-logo.svg');
+  background-repeat: no-repeat;
+  background-size: 100% auto;
+  margin: 30px auto 0;
+}
 
 .admin-wrapper p a {
   color: var(--light) !important;

--- a/public/custom.css
+++ b/public/custom.css
@@ -85,7 +85,7 @@
 }
 
 .theme-default .status {
-  border-bottom: 4px solid var(--dark);
+  border-bottom: 10px solid var(--dark);
 }
 
 .theme-default .column-link--transparent {
@@ -548,7 +548,7 @@ p a {
 }
 
 .icon-button {
-  color: var(--accent);
+  color: var(--dark-light);
 }
 
 .icon-button:hover {

--- a/public/custom.css
+++ b/public/custom.css
@@ -1,0 +1,552 @@
+/* Globals*/
+
+:root {
+  --dark: #000;
+  --medium-dark: #111111;
+  --light-dark: #2B2B2B;
+  --light: #FFF;
+  --medium-light: #C5C5C5;
+  --dark-light: #858585;
+  --accent: #3F8FF5;
+  --color-2: #D72FD6;
+  --color-3: #F6CA45;
+}
+
+.button,
+.button.logo-button {
+  background-color: var(--accent);
+}
+
+.button:active, .button:focus, .button:hover, .button.logo-button:hover {
+    background-color: var(--light);
+    color: var(--accent);
+}
+
+.button.logo-button.button--destructive:active, .button.logo-button.button--destructive:focus, .button.logo-button.button--destructive:hover {
+    background: var(--accent);
+    color: var(--light);
+}
+
+.button.button-secondary {
+    color: var(--dark-light);
+    border: 1px solid var(--dark-light);
+}
+
+.button.button-secondary:hover {
+    color: var(--light);
+    border: 1px solid var(--accent);
+    background: var(--accent);
+}
+
+.button.button-secondary:disabled:hover {
+    color: var(--dark-light);
+    background: none;
+    border: 1px solid var(--dark-light);
+}
+
+.button.disabled, .button:disabled {
+    background-color: var(--dark-light);
+    color: var(--medium-light);
+}
+
+p, p a {
+    color: var(--dark-light) !important;
+}
+
+a.mention {
+    color: var(--light) !important;
+}
+
+/* Layout */
+
+::-webkit-scrollbar-thumb {
+    background: var(--light-dark);
+}
+
+.ui {
+  background: var(--dark);
+}
+
+.column>.scrollable {
+    background: none;
+}
+
+.empty-column-indicator {
+    background: var(--medium-dark);
+}
+
+.empty-column-indicator span {
+    color: var(--dark-light);
+}
+
+.load-more {
+    color: var(--light);
+}
+
+.load-more:hover {
+    background: var(--medium-dark);
+    color: var(--accent);
+}
+
+.item-list {
+  background: var(--medium-dark);
+}
+
+.drawer__header {
+    background: var(--light-dark);
+}
+
+.drawer__header a:hover {
+    background: var(--accent);
+}
+
+.drawer__tab {
+    color: var(--light);
+}
+
+.compose-form {
+    background: var(--medium-dark);
+}
+
+.reply-indicator {
+    background: var(--light-dark);
+}
+
+.reply-indicator__display-name {
+    color: var(--light);
+}
+
+.display-name__account {
+    color: var(--dark-light);
+}
+
+.drawer__inner__mastodon {
+    background: none;
+    background-image: none;
+    background-color: var(--medium-dark);
+}
+
+.drawer__inner__mastodon img {
+    display: none;
+}
+
+.column-header,
+.column-header__button {
+  background: var(--light-dark);
+  color: white;
+}
+
+.column-header__button.active, .column-header__button.active:hover, .column-header__button:hover {
+    background: var(--light-dark);
+    color: var(--light);
+}
+
+.column-header__collapsible-inner {
+    background: var(--light-dark);
+}
+
+.column-header__collapsible__extra {
+    color: var(--light);
+}
+
+.column-settings__section {
+    color: var(--light);
+}
+
+.column-back-button {
+    background: var(--light-dark);
+    color: var(--light);
+}
+
+.setting-toggle__label {
+    color: var(--dark-light);
+}
+
+.react-toggle--checked .react-toggle-track {
+    background-color: var(--accent);
+}
+
+.react-toggle--checked:is(:hover,:focus-within):not(.react-toggle--disabled) .react-toggle-track {
+    background-color: var(--accent) !important;
+}
+
+.react-toggle--checked .react-toggle-thumb {
+    border-color: var(--accent);
+}
+
+.dismissable-banner {
+  background: var(--medium-dark);
+  border-bottom: 1px solid var(--light-dark);
+}
+
+.fa-close:before, .fa-remove:before, .fa-times:before {
+    color: var(--light);
+}
+
+.search__input {
+    background: var(--light-dark);
+    color: var(--medium-dark);
+}
+
+.search__input:focus {
+    background: var(--light);
+}
+
+.search__input::placeholder {
+    color: var(--dark-light);
+}
+
+.navigation-bar {
+    background: var(--medium-dark);
+}
+
+.navigation-bar a {
+    color: var(--dark-light);
+}
+
+.status {
+    border-bottom: 4px solid var(--dark);
+}
+
+.column-header__back-button {
+    background: var(--light-dark);
+    color: var(--light);
+}
+
+.column-inline-form {
+    background: var(--light-dark);
+}
+
+.getting-started__wrapper {
+    background: var(--medium-dark);
+}
+
+.account__header__bar .avatar .account__avatar {
+    background: var(--medium-dark);
+    border: 2px solid var(--medium-dark);
+}
+
+.text-btn {
+    color: var(--light);
+}
+
+.getting-started__trends h4 {
+    color: var(--light);
+    border-bottom: var(--light-dark);
+}
+
+.trends__item__name a {
+    color: var(--light);
+}
+
+.trends__item__name {
+    color: var(--dark-light);
+}
+
+.getting-started__trends .trends__item__current {
+    color: var(--light);
+}
+
+/* Account */
+
+.navigation-bar__profile a {
+    color: var(--light);
+}
+
+.account__header {
+    background: var(--light-dark);
+}
+
+.account__header__account-note label {
+    color: var(--light);
+}
+
+.account__header__account-note textarea,
+.account__header__account-note textarea::placeholder {
+    color: var(--dark-light);
+}
+
+.account__header__account-note textarea:focus {
+    background: var(--medium-dark);
+    color: var(--light);
+}
+
+.account__header__image {
+    background: var(--light-dark);
+}
+
+.column-subheading {
+    color: var(--dark-light);
+    background: var(--light-dark);
+}
+
+.account__header__tabs__buttons .icon-button {
+    border: 1px solid var(--dark-light);
+}
+
+.icon-button:active, .icon-button:focus, .icon-button:hover {
+    color: var(--light);
+}
+
+.icon-button.active {
+    color: var(--accent);
+}
+
+.icon-button.disabled {
+    color: var(--accent);
+}
+
+.account__header__bio .account__header__fields {
+    background: var(--medium-dark);
+}
+
+.account__header__bio .account__header__fields dt,
+.account__header__bio .account__header__fields dd {
+    color: var(--dark-light);
+}
+
+.account__header__bio .account__header__fields dl {
+    border-bootom-color: var(--light-dark);
+}
+
+.account__header__tabs {
+    background: transparent;
+}
+
+.account__header__tabs__name h1 small {
+    color: var(--dark-light);
+}
+
+.account__header__extra__links a {
+    color: var(--light);
+}
+
+.account__header__bar {
+    border-bottom: none;
+}
+
+.account {
+    border-bottom: 4px solid var(--dark);
+}
+
+.account__header__bio .account__header__fields a {
+    color: var(--accent);
+}
+
+.account__header__bio .account__header__fields .verified a, .account__header__bio .account__header__fields .verified dd, .account__header__bio .account__header__fields .verified dt {
+    color: var(--light);
+}
+
+/* Navigation */
+
+.navigation-panel hr {
+    display: none;
+}
+
+.navigation-panel__logo {
+  padding: 1rem 1rem 0 1rem;
+}
+
+.navigation-panel__logo hr {
+  margin-top: 1.5rem;
+}
+
+.navigation-panel__logo a svg {
+  display: none;
+}
+
+.navigation-panel__logo a, 
+.navigation-panel__logo a:hover {
+    margin-bottom: 0.75rem;
+    width: 3rem;
+    height: 3rem;
+    background: none;
+    background-image: url('https://cdn.shopify.com/s/files/1/0614/6565/7577/files/mammoth-logo.svg');
+    background-repeat: no-repeat;
+    background-size: 100% auto;
+}
+
+.column-link {
+    background: var(--medium-dark);
+    color: var(--light);
+}
+
+.column-link--transparent {
+    color: var(--medium-light);
+}
+
+.column-link--transparent:hover {
+    color: var(--light);
+}
+
+.column-link:active, .column-link:focus, .column-link:hover {
+    background: none;
+    color: var(--accent);
+}
+
+.column-link--transparent.active {
+  color: var(--light);
+  background: var(--accent);
+}
+
+.icon-with-badge__badge {
+    background: var(--accent);
+    border: 2px solid var(--dark);
+}
+
+.column-header.active .column-header__icon {
+    color: var(--accent);
+    text-shadow: 0 0 10px rgb( 244 88 0 / 40%);
+}
+
+.column-header__wrapper.active {
+    box-shadow: 0 1px 0 rgb( 0 0 0 / 100%);
+}
+
+.column-header__wrapper.active:before {
+    background: none;
+}
+
+/* Links */
+
+.status__display-name,
+.display-name__account {
+    color: var(--dark-light);
+}
+
+.status__relative-time {
+  color: var(--medium-light);
+}
+
+.icon-button {
+    color: var(--accent);
+}
+
+.icon-button:hover {
+    color: var(--light);
+}
+
+button.icon-button i.fa-retweet {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='22' height='209'%3E%3Cpath d='M4.97 3.16c-.1.03-.17.1-.22.18L.8 8.24c-.2.3.03.78.4.8H3.6v2.68c0 4.26-.55 3.62 3.66 3.62h7.66l-2.3-2.84c-.03-.02-.03-.04-.05-.06H7.27c-.44 0-.72-.3-.72-.72v-2.7h2.5c.37.03.63-.48.4-.77L5.5 3.35c-.12-.17-.34-.25-.53-.2zm12.16.43c-.55-.02-1.32.02-2.4.02H7.1l2.32 2.85.03.06h5.25c.42 0 .72.28.72.72v2.7h-2.5c-.36.02-.56.54-.3.8l3.92 4.9c.18.25.6.25.78 0l3.94-4.9c.26-.28 0-.83-.37-.8H18.4v-2.7c0-3.15.4-3.62-1.25-3.66z' fill='%233F8FF5' stroke-width='0'/%3E%3Cpath d='M7.78 19.66c-.24.02-.44.25-.44.5v2.46h-.06c-1.08 0-1.86-.03-2.4-.03-1.64 0-1.25.43-1.25 3.65v4.47c0 4.26-.56 3.62 3.65 3.62H8.5l-1.3-1.06c-.1-.08-.18-.2-.2-.3-.02-.17.06-.35.2-.45l1.33-1.1H7.28c-.44 0-.72-.3-.72-.7v-4.48c0-.44.28-.72.72-.72h.06v2.5c0 .38.54.63.82.38l4.9-3.93c.25-.18.25-.6 0-.78l-4.9-3.92c-.1-.1-.24-.14-.38-.12zm9.34 2.93c-.54-.02-1.3.02-2.4.02h-1.25l1.3 1.07c.1.07.18.2.2.33.02.16-.06.3-.2.4l-1.33 1.1h1.28c.42 0 .72.28.72.72v4.47c0 .42-.3.72-.72.72h-.1v-2.47c0-.3-.3-.53-.6-.47-.07 0-.14.05-.2.1l-4.9 3.93c-.26.18-.26.6 0 .78l4.9 3.92c.27.25.82 0 .8-.38v-2.5h.1c4.27 0 3.65.67 3.65-3.62v-4.47c0-3.15.4-3.62-1.25-3.66zM10.34 38.66c-.24.02-.44.25-.43.5v2.47H7.3c-1.08 0-1.86-.04-2.4-.04-1.64 0-1.25.43-1.25 3.65v4.47c0 3.66-.23 3.7 2.34 3.66l-1.34-1.1c-.1-.08-.18-.2-.2-.3 0-.17.07-.35.2-.45l1.96-1.6c-.03-.06-.04-.13-.04-.2v-4.48c0-.44.28-.72.72-.72H9.9v2.5c0 .36.5.6.8.38l4.93-3.93c.24-.18.24-.6 0-.78l-4.94-3.92c-.1-.08-.23-.13-.36-.12zm5.63 2.93l1.34 1.1c.1.07.18.2.2.33.02.16-.03.3-.16.4l-1.96 1.6c.02.07.06.13.06.22v4.47c0 .42-.3.72-.72.72h-2.66v-2.47c0-.3-.3-.53-.6-.47-.06.02-.12.05-.18.1l-4.94 3.93c-.24.18-.24.6 0 .78l4.94 3.92c.28.22.78-.02.78-.38v-2.5h2.66c4.27 0 3.65.67 3.65-3.62v-4.47c0-3.66.34-3.7-2.4-3.66zM13.06 57.66c-.23.03-.4.26-.4.5v2.47H7.28c-1.08 0-1.86-.04-2.4-.04-1.64 0-1.25.43-1.25 3.65v4.87l2.93-2.37v-2.5c0-.44.28-.72.72-.72h5.38v2.5c0 .36.5.6.78.38l4.94-3.93c.24-.18.24-.6 0-.78l-4.94-3.92c-.1-.1-.24-.14-.38-.12zm5.3 6.15l-2.92 2.4v2.52c0 .42-.3.72-.72.72h-5.4v-2.47c0-.3-.32-.53-.6-.47-.07.02-.13.05-.2.1L3.6 70.52c-.25.18-.25.6 0 .78l4.93 3.92c.28.22.78-.02.78-.38v-2.5h5.42c4.27 0 3.65.67 3.65-3.62v-4.47-.44zM19.25 78.8c-.1.03-.2.1-.28.17l-.9.9c-.44-.3-1.36-.25-3.35-.25H7.28c-1.08 0-1.86-.03-2.4-.03-1.64 0-1.25.43-1.25 3.65v.7l2.93.3v-1c0-.44.28-.72.72-.72h7.44c.2 0 .37.08.5.2l-1.8 1.8c-.25.26-.08.76.27.8l6.27.7c.28.03.56-.25.53-.53l-.7-6.25c0-.27-.3-.48-.55-.44zm-17.2 6.1c-.2.07-.36.3-.33.54l.7 6.25c.02.36.58.55.83.27l.8-.8c.02 0 .04-.02.04 0 .46.24 1.37.17 3.18.17h7.44c4.27 0 3.65.67 3.65-3.62v-.75l-2.93-.3v1.05c0 .42-.3.72-.72.72H7.28c-.15 0-.3-.03-.4-.1L8.8 86.4c.3-.24.1-.8-.27-.84l-6.28-.65h-.2zM4.88 98.6c-1.33 0-1.34.48-1.3 2.3l1.14-1.37c.08-.1.22-.17.34-.2.16 0 .34.08.44.2l1.66 2.03c.04 0 .07-.03.12-.03h7.44c.34 0 .57.2.65.5h-2.43c-.34.05-.53.52-.3.78l3.92 4.95c.18.24.6.24.78 0l3.94-4.94c.22-.27-.02-.76-.37-.77H18.4c.02-3.9.6-3.4-3.66-3.4H7.28c-1.08 0-1.86-.04-2.4-.04zm.15 2.46c-.1.03-.2.1-.28.2l-3.94 4.9c-.2.28.03.77.4.78H3.6c-.02 3.94-.45 3.4 3.66 3.4h7.44c3.65 0 3.74.3 3.7-2.25l-1.1 1.34c-.1.1-.2.17-.32.2-.16 0-.34-.08-.44-.2l-1.65-2.03c-.06.02-.1.04-.18.04H7.28c-.35 0-.57-.2-.66-.5h2.44c.37 0 .63-.5.4-.78l-3.96-4.9c-.1-.15-.3-.23-.47-.2zM4.88 117.6c-1.16 0-1.3.3-1.3 1.56l1.14-1.38c.08-.1.22-.14.34-.16.16 0 .34.04.44.16l2.22 2.75h7c.42 0 .72.28.72.72v.53h-2.6c-.3.1-.43.54-.2.78l3.92 4.9c.18.25.6.25.78 0l3.94-4.9c.22-.28-.02-.77-.37-.78H18.4v-.53c0-4.2.72-3.63-3.66-3.63H7.28c-1.08 0-1.86-.03-2.4-.03zm.1 1.74c-.1.03-.17.1-.23.16L.8 124.44c-.2.28.03.77.4.78H3.6v.5c0 4.26-.55 3.62 3.66 3.62h7.44c1.03 0 1.74.02 2.28 0-.16.02-.34-.03-.44-.15l-2.22-2.76H7.28c-.44 0-.72-.3-.72-.72v-.5h2.5c.37.02.63-.5.4-.78L5.5 119.5c-.12-.15-.34-.22-.53-.16zm12.02 10c1.2-.02 1.4-.25 1.4-1.53l-1.1 1.36c-.07.1-.17.17-.3.18zM5.94 136.6l2.37 2.93h6.42c.42 0 .72.28.72.72v1.25h-2.6c-.3.1-.43.54-.2.78l3.92 4.9c.18.25.6.25.78 0l3.94-4.9c.22-.28-.02-.77-.37-.78H18.4v-1.25c0-4.2.72-3.63-3.66-3.63H7.28c-.6 0-.92-.02-1.34-.03zm-1.72.06c-.4.08-.54.3-.6.75l.6-.74zm.84.93c-.12 0-.24.08-.3.18l-3.95 4.9c-.24.3 0 .83.4.82H3.6v1.22c0 4.26-.55 3.62 3.66 3.62h7.44c.63 0 .97.02 1.4.03l-2.37-2.93H7.28c-.44 0-.72-.3-.72-.72v-1.22h2.5c.4.04.67-.53.4-.8l-3.96-4.92c-.1-.13-.27-.2-.44-.2zm13.28 10.03l-.56.7c.36-.07.5-.3.56-.7zM17.13 155.6c-.55-.02-1.32.03-2.4.03h-8.2l2.38 2.9h5.82c.42 0 .72.28.72.72v1.97H12.9c-.32.06-.48.52-.28.78l3.94 4.94c.2.23.6.22.78-.03l3.94-4.9c.22-.28-.02-.77-.37-.78H18.4v-1.97c0-3.15.4-3.62-1.25-3.66zm-12.1.28c-.1.02-.2.1-.28.18l-3.94 4.9c-.2.3.03.78.4.8H3.6v1.96c0 4.26-.55 3.62 3.66 3.62h8.24l-2.36-2.9H7.28c-.44 0-.72-.3-.72-.72v-1.97h2.5c.37.02.63-.5.4-.78l-3.96-4.9c-.1-.15-.3-.22-.47-.2zM5.13 174.5c-.15 0-.3.07-.38.2L.8 179.6c-.24.27 0 .82.4.8H3.6v2.32c0 4.26-.55 3.62 3.66 3.62h7.94l-2.35-2.9h-5.6c-.43 0-.7-.3-.7-.72v-2.3h2.5c.38.03.66-.54.4-.83l-3.97-4.9c-.1-.13-.23-.2-.38-.2zm12 .1c-.55-.02-1.32.03-2.4.03H6.83l2.35 2.9h5.52c.42 0 .72.28.72.72v2.34h-2.6c-.3.1-.43.53-.2.78l3.92 4.9c.18.24.6.24.78 0l3.94-4.9c.22-.3-.02-.78-.37-.8H18.4v-2.33c0-3.15.4-3.62-1.25-3.66zM4.97 193.16c-.1.03-.17.1-.22.18l-3.94 4.9c-.2.3.03.78.4.8H3.6v2.68c0 4.26-.55 3.62 3.66 3.62h7.66l-2.3-2.84c-.03-.02-.03-.04-.05-.06H7.27c-.44 0-.72-.3-.72-.72v-2.7h2.5c.37.03.63-.48.4-.77l-3.96-4.9c-.12-.17-.34-.25-.53-.2zm12.16.43c-.55-.02-1.32.03-2.4.03H7.1l2.32 2.84.03.06h5.25c.42 0 .72.28.72.72v2.7h-2.5c-.36.02-.56.54-.3.8l3.92 4.9c.18.25.6.25.78 0l3.94-4.9c.26-.28 0-.83-.37-.8H18.4v-2.7c0-3.15.4-3.62-1.25-3.66z' fill='%233F8FF5' stroke-width='0'/%3E%3C/svg%3E");
+}
+
+button.icon-button i.fa-retweet:hover {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='22' height='209'%3E%3Cpath d='M4.97 3.16c-.1.03-.17.1-.22.18L.8 8.24c-.2.3.03.78.4.8H3.6v2.68c0 4.26-.55 3.62 3.66 3.62h7.66l-2.3-2.84c-.03-.02-.03-.04-.05-.06H7.27c-.44 0-.72-.3-.72-.72v-2.7h2.5c.37.03.63-.48.4-.77L5.5 3.35c-.12-.17-.34-.25-.53-.2zm12.16.43c-.55-.02-1.32.02-2.4.02H7.1l2.32 2.85.03.06h5.25c.42 0 .72.28.72.72v2.7h-2.5c-.36.02-.56.54-.3.8l3.92 4.9c.18.25.6.25.78 0l3.94-4.9c.26-.28 0-.83-.37-.8H18.4v-2.7c0-3.15.4-3.62-1.25-3.66z' fill='%23ffffff' stroke-width='0'/%3E%3Cpath d='M7.78 19.66c-.24.02-.44.25-.44.5v2.46h-.06c-1.08 0-1.86-.03-2.4-.03-1.64 0-1.25.43-1.25 3.65v4.47c0 4.26-.56 3.62 3.65 3.62H8.5l-1.3-1.06c-.1-.08-.18-.2-.2-.3-.02-.17.06-.35.2-.45l1.33-1.1H7.28c-.44 0-.72-.3-.72-.7v-4.48c0-.44.28-.72.72-.72h.06v2.5c0 .38.54.63.82.38l4.9-3.93c.25-.18.25-.6 0-.78l-4.9-3.92c-.1-.1-.24-.14-.38-.12zm9.34 2.93c-.54-.02-1.3.02-2.4.02h-1.25l1.3 1.07c.1.07.18.2.2.33.02.16-.06.3-.2.4l-1.33 1.1h1.28c.42 0 .72.28.72.72v4.47c0 .42-.3.72-.72.72h-.1v-2.47c0-.3-.3-.53-.6-.47-.07 0-.14.05-.2.1l-4.9 3.93c-.26.18-.26.6 0 .78l4.9 3.92c.27.25.82 0 .8-.38v-2.5h.1c4.27 0 3.65.67 3.65-3.62v-4.47c0-3.15.4-3.62-1.25-3.66zM10.34 38.66c-.24.02-.44.25-.43.5v2.47H7.3c-1.08 0-1.86-.04-2.4-.04-1.64 0-1.25.43-1.25 3.65v4.47c0 3.66-.23 3.7 2.34 3.66l-1.34-1.1c-.1-.08-.18-.2-.2-.3 0-.17.07-.35.2-.45l1.96-1.6c-.03-.06-.04-.13-.04-.2v-4.48c0-.44.28-.72.72-.72H9.9v2.5c0 .36.5.6.8.38l4.93-3.93c.24-.18.24-.6 0-.78l-4.94-3.92c-.1-.08-.23-.13-.36-.12zm5.63 2.93l1.34 1.1c.1.07.18.2.2.33.02.16-.03.3-.16.4l-1.96 1.6c.02.07.06.13.06.22v4.47c0 .42-.3.72-.72.72h-2.66v-2.47c0-.3-.3-.53-.6-.47-.06.02-.12.05-.18.1l-4.94 3.93c-.24.18-.24.6 0 .78l4.94 3.92c.28.22.78-.02.78-.38v-2.5h2.66c4.27 0 3.65.67 3.65-3.62v-4.47c0-3.66.34-3.7-2.4-3.66zM13.06 57.66c-.23.03-.4.26-.4.5v2.47H7.28c-1.08 0-1.86-.04-2.4-.04-1.64 0-1.25.43-1.25 3.65v4.87l2.93-2.37v-2.5c0-.44.28-.72.72-.72h5.38v2.5c0 .36.5.6.78.38l4.94-3.93c.24-.18.24-.6 0-.78l-4.94-3.92c-.1-.1-.24-.14-.38-.12zm5.3 6.15l-2.92 2.4v2.52c0 .42-.3.72-.72.72h-5.4v-2.47c0-.3-.32-.53-.6-.47-.07.02-.13.05-.2.1L3.6 70.52c-.25.18-.25.6 0 .78l4.93 3.92c.28.22.78-.02.78-.38v-2.5h5.42c4.27 0 3.65.67 3.65-3.62v-4.47-.44zM19.25 78.8c-.1.03-.2.1-.28.17l-.9.9c-.44-.3-1.36-.25-3.35-.25H7.28c-1.08 0-1.86-.03-2.4-.03-1.64 0-1.25.43-1.25 3.65v.7l2.93.3v-1c0-.44.28-.72.72-.72h7.44c.2 0 .37.08.5.2l-1.8 1.8c-.25.26-.08.76.27.8l6.27.7c.28.03.56-.25.53-.53l-.7-6.25c0-.27-.3-.48-.55-.44zm-17.2 6.1c-.2.07-.36.3-.33.54l.7 6.25c.02.36.58.55.83.27l.8-.8c.02 0 .04-.02.04 0 .46.24 1.37.17 3.18.17h7.44c4.27 0 3.65.67 3.65-3.62v-.75l-2.93-.3v1.05c0 .42-.3.72-.72.72H7.28c-.15 0-.3-.03-.4-.1L8.8 86.4c.3-.24.1-.8-.27-.84l-6.28-.65h-.2zM4.88 98.6c-1.33 0-1.34.48-1.3 2.3l1.14-1.37c.08-.1.22-.17.34-.2.16 0 .34.08.44.2l1.66 2.03c.04 0 .07-.03.12-.03h7.44c.34 0 .57.2.65.5h-2.43c-.34.05-.53.52-.3.78l3.92 4.95c.18.24.6.24.78 0l3.94-4.94c.22-.27-.02-.76-.37-.77H18.4c.02-3.9.6-3.4-3.66-3.4H7.28c-1.08 0-1.86-.04-2.4-.04zm.15 2.46c-.1.03-.2.1-.28.2l-3.94 4.9c-.2.28.03.77.4.78H3.6c-.02 3.94-.45 3.4 3.66 3.4h7.44c3.65 0 3.74.3 3.7-2.25l-1.1 1.34c-.1.1-.2.17-.32.2-.16 0-.34-.08-.44-.2l-1.65-2.03c-.06.02-.1.04-.18.04H7.28c-.35 0-.57-.2-.66-.5h2.44c.37 0 .63-.5.4-.78l-3.96-4.9c-.1-.15-.3-.23-.47-.2zM4.88 117.6c-1.16 0-1.3.3-1.3 1.56l1.14-1.38c.08-.1.22-.14.34-.16.16 0 .34.04.44.16l2.22 2.75h7c.42 0 .72.28.72.72v.53h-2.6c-.3.1-.43.54-.2.78l3.92 4.9c.18.25.6.25.78 0l3.94-4.9c.22-.28-.02-.77-.37-.78H18.4v-.53c0-4.2.72-3.63-3.66-3.63H7.28c-1.08 0-1.86-.03-2.4-.03zm.1 1.74c-.1.03-.17.1-.23.16L.8 124.44c-.2.28.03.77.4.78H3.6v.5c0 4.26-.55 3.62 3.66 3.62h7.44c1.03 0 1.74.02 2.28 0-.16.02-.34-.03-.44-.15l-2.22-2.76H7.28c-.44 0-.72-.3-.72-.72v-.5h2.5c.37.02.63-.5.4-.78L5.5 119.5c-.12-.15-.34-.22-.53-.16zm12.02 10c1.2-.02 1.4-.25 1.4-1.53l-1.1 1.36c-.07.1-.17.17-.3.18zM5.94 136.6l2.37 2.93h6.42c.42 0 .72.28.72.72v1.25h-2.6c-.3.1-.43.54-.2.78l3.92 4.9c.18.25.6.25.78 0l3.94-4.9c.22-.28-.02-.77-.37-.78H18.4v-1.25c0-4.2.72-3.63-3.66-3.63H7.28c-.6 0-.92-.02-1.34-.03zm-1.72.06c-.4.08-.54.3-.6.75l.6-.74zm.84.93c-.12 0-.24.08-.3.18l-3.95 4.9c-.24.3 0 .83.4.82H3.6v1.22c0 4.26-.55 3.62 3.66 3.62h7.44c.63 0 .97.02 1.4.03l-2.37-2.93H7.28c-.44 0-.72-.3-.72-.72v-1.22h2.5c.4.04.67-.53.4-.8l-3.96-4.92c-.1-.13-.27-.2-.44-.2zm13.28 10.03l-.56.7c.36-.07.5-.3.56-.7zM17.13 155.6c-.55-.02-1.32.03-2.4.03h-8.2l2.38 2.9h5.82c.42 0 .72.28.72.72v1.97H12.9c-.32.06-.48.52-.28.78l3.94 4.94c.2.23.6.22.78-.03l3.94-4.9c.22-.28-.02-.77-.37-.78H18.4v-1.97c0-3.15.4-3.62-1.25-3.66zm-12.1.28c-.1.02-.2.1-.28.18l-3.94 4.9c-.2.3.03.78.4.8H3.6v1.96c0 4.26-.55 3.62 3.66 3.62h8.24l-2.36-2.9H7.28c-.44 0-.72-.3-.72-.72v-1.97h2.5c.37.02.63-.5.4-.78l-3.96-4.9c-.1-.15-.3-.22-.47-.2zM5.13 174.5c-.15 0-.3.07-.38.2L.8 179.6c-.24.27 0 .82.4.8H3.6v2.32c0 4.26-.55 3.62 3.66 3.62h7.94l-2.35-2.9h-5.6c-.43 0-.7-.3-.7-.72v-2.3h2.5c.38.03.66-.54.4-.83l-3.97-4.9c-.1-.13-.23-.2-.38-.2zm12 .1c-.55-.02-1.32.03-2.4.03H6.83l2.35 2.9h5.52c.42 0 .72.28.72.72v2.34h-2.6c-.3.1-.43.53-.2.78l3.92 4.9c.18.24.6.24.78 0l3.94-4.9c.22-.3-.02-.78-.37-.8H18.4v-2.33c0-3.15.4-3.62-1.25-3.66zM4.97 193.16c-.1.03-.17.1-.22.18l-3.94 4.9c-.2.3.03.78.4.8H3.6v2.68c0 4.26-.55 3.62 3.66 3.62h7.66l-2.3-2.84c-.03-.02-.03-.04-.05-.06H7.27c-.44 0-.72-.3-.72-.72v-2.7h2.5c.37.03.63-.48.4-.77l-3.96-4.9c-.12-.17-.34-.25-.53-.2zm12.16.43c-.55-.02-1.32.03-2.4.03H7.1l2.32 2.84.03.06h5.25c.42 0 .72.28.72.72v2.7h-2.5c-.36.02-.56.54-.3.8l3.92 4.9c.18.25.6.25.78 0l3.94-4.9c.26-.28 0-.83-.37-.8H18.4v-2.7c0-3.15.4-3.62-1.25-3.66z' fill='%23ffffff' stroke-width='0'/%3E%3C/svg%3E");
+}
+
+/* Posts */
+
+.focusable:focus {
+    background: none;
+}
+
+.muted .status__content, .muted .status__content a, .muted .status__content p, .muted .status__display-name strong {
+    color: var(--light);
+}
+
+.account__section-headline a.active, .account__section-headline button.active, .notification__filter-bar a.active, .notification__filter-bar button.active {
+    background: var(--accent);
+    color: var(--light);
+}
+
+
+.account__section-headline a.active:after, .account__section-headline button.active:after, .notification__filter-bar a.active:after, .notification__filter-bar button.active:after {
+    border-color: transparent transparent var(--medium-dark);
+}
+
+.account__section-headline a.active:after, .account__section-headline a.active:before, .account__section-headline button.active:after, .account__section-headline button.active:before, .notification__filter-bar a.active:after, .notification__filter-bar a.active:before, .notification__filter-bar button.active:after, .notification__filter-bar button.active:before {
+   border-color: transparent transparent var(--medium-dark);
+}
+
+.account__section-headline a, .account__section-headline button, .notification__filter-bar a, .notification__filter-bar button {
+    background: var(--light-dark);
+    color: var(--dark-light);
+}
+
+.account__section-headline a:hover, .account__section-headline button:hover, .notification__filter-bar a:hover, .notification__filter-bar button:hover {
+    color: var(--light);
+}
+
+.account__section-headline, .notification__filter-bar {
+    border-bottom: none;
+}
+
+.notification__message {
+    color: var(--light);
+}
+
+.notification.unread:before, .status__wrapper.unread:before {
+    border-left: 2px solid var(--accent);
+}
+
+.icon-button.star-icon.active, .notification__favourite-icon-wrapper .star-icon {
+    color: var(--color-3);
+}
+
+.status__prepend {
+    color: var(--light);
+}
+
+.status__prepend .status__display-name strong {
+    color: var(--light);
+}
+
+.notification__message .fa {
+    color: var(--light) !important;
+}
+
+.poll__chart {
+    background: var(--light-dark);
+}
+
+.poll__chart.leading {
+    background: var(--accent);
+}
+
+.poll__link {
+    color: var(--dark-light);
+}
+
+.poll__footer {
+    color: var(--dark-light);
+}
+
+.poll__input {
+    border: 1px solid var(--dark-light);
+}
+
+.poll__input.active {
+    border-color: var(--light);
+    background: var(--accent);
+}
+
+.poll__input:active, .poll__input:focus, .poll__input:hover {
+    border-color: var(--accent);
+}
+
+.unhandled-link {
+    color: var(--light) !important;
+}
+
+.status-card,
+.status-card.compact {
+    border-color: var(--light-dark);
+    color: var(--dark-light);
+}
+
+.status-card__image {
+    background: var(--medium-dark);
+}
+
+.status-card__title {
+    color: var(--light);
+}
+
+a.status-card.compact:hover {
+    background-color: var(--light-dark);
+}
+
+.reply-indicator__content .status__content__spoiler-link, .status__content .status__content__spoiler-link {
+    background: var(--light);
+    color: var(--medium-dark);
+}

--- a/public/custom.css
+++ b/public/custom.css
@@ -779,7 +779,6 @@ button.icon-button i.fa-retweet:hover {
   background: var(--accent);
 }
 
-
 /***********************************
 * REPLACE MASTODON DEFAULT LOGO
 ***********************************/
@@ -799,7 +798,6 @@ button.icon-button i.fa-retweet:hover {
   background-repeat: no-repeat;
   background-size: 100% auto;
 }
-
 
 @media screen and (max-width: 1174px) {
   .layout-single-column .ui__header__logo svg {

--- a/public/custom.css
+++ b/public/custom.css
@@ -1,4 +1,4 @@
-/* Globals*/
+/* Globals */
 
 :root {
   --dark: #000;
@@ -7,6 +7,7 @@
   --light: #FFF;
   --medium-light: #C5C5C5;
   --dark-light: #858585;
+  --light-accent: #539af7;
   --accent: #3F8FF5;
   --color-2: #D72FD6;
   --color-3: #F6CA45;
@@ -18,49 +19,60 @@
 }
 
 .button:active, .button:focus, .button:hover, .button.logo-button:hover {
-    background-color: var(--light);
-    color: var(--accent);
+  background-color: var(--light);
+  color: var(--accent);
 }
 
 .button.logo-button.button--destructive:active, .button.logo-button.button--destructive:focus, .button.logo-button.button--destructive:hover {
-    background: var(--accent);
-    color: var(--light);
+  background: var(--accent);
+  color: var(--light);
 }
 
 .button.button-secondary {
-    color: var(--dark-light);
-    border: 1px solid var(--dark-light);
+  color: var(--dark-light);
+  border: 1px solid var(--dark-light);
 }
 
 .button.button-secondary:hover {
-    color: var(--light);
-    border: 1px solid var(--accent);
-    background: var(--accent);
+  color: var(--light);
+  border: 1px solid var(--accent);
+  background: var(--accent);
 }
 
 .button.button-secondary:disabled:hover {
-    color: var(--dark-light);
-    background: none;
-    border: 1px solid var(--dark-light);
+  color: var(--dark-light);
+  background: none;
+  border: 1px solid var(--dark-light);
+}
+
+.button.button-tertiary {
+  color: var(--accent);
+  border: 1px solid var(--accent);
+}
+
+.button.button-tertiary:hover {
+  background: var(--accent);
+  color: var(--light);
+  border: 0;
 }
 
 .button.disabled, .button:disabled {
-    background-color: var(--dark-light);
-    color: var(--medium-light);
+  background-color: var(--dark-light);
+  color: var(--medium-light);
 }
 
 p, p a {
-    color: var(--dark-light) !important;
+  color: var(--dark-light) !important;
 }
 
 a.mention {
-    color: var(--light) !important;
+  color: var(--light) !important;
 }
 
 /* Layout */
 
 ::-webkit-scrollbar-thumb {
-    background: var(--light-dark);
+  background: var(--light-dark);
 }
 
 .ui {
@@ -68,24 +80,24 @@ a.mention {
 }
 
 .column>.scrollable {
-    background: none;
+  background: none;
 }
 
 .empty-column-indicator {
-    background: var(--medium-dark);
+  background: var(--medium-dark);
 }
 
 .empty-column-indicator span {
-    color: var(--dark-light);
+  color: var(--dark-light);
 }
 
 .load-more {
-    color: var(--light);
+  color: var(--light);
 }
 
 .load-more:hover {
-    background: var(--medium-dark);
-    color: var(--accent);
+  background: var(--medium-dark);
+  color: var(--accent);
 }
 
 .item-list {
@@ -93,41 +105,41 @@ a.mention {
 }
 
 .drawer__header {
-    background: var(--light-dark);
+  background: var(--light-dark);
 }
 
 .drawer__header a:hover {
-    background: var(--accent);
+  background: var(--accent);
 }
 
 .drawer__tab {
-    color: var(--light);
+  color: var(--light);
 }
 
 .compose-form {
-    background: var(--medium-dark);
+  background: var(--medium-dark);
 }
 
 .reply-indicator {
-    background: var(--light-dark);
+  background: var(--light-dark);
 }
 
 .reply-indicator__display-name {
-    color: var(--light);
+  color: var(--light);
 }
 
 .display-name__account {
-    color: var(--dark-light);
+  color: var(--dark-light);
 }
 
 .drawer__inner__mastodon {
-    background: none;
-    background-image: none;
-    background-color: var(--medium-dark);
+  background: none;
+  background-image: none;
+  background-color: var(--medium-dark);
 }
 
 .drawer__inner__mastodon img {
-    display: none;
+  display: none;
 }
 
 .column-header,
@@ -137,41 +149,41 @@ a.mention {
 }
 
 .column-header__button.active, .column-header__button.active:hover, .column-header__button:hover {
-    background: var(--light-dark);
-    color: var(--light);
+  background: var(--light-dark);
+  color: var(--light);
 }
 
 .column-header__collapsible-inner {
-    background: var(--light-dark);
+  background: var(--light-dark);
 }
 
 .column-header__collapsible__extra {
-    color: var(--light);
+  color: var(--light);
 }
 
 .column-settings__section {
-    color: var(--light);
+  color: var(--light);
 }
 
 .column-back-button {
-    background: var(--light-dark);
-    color: var(--light);
+  background: var(--light-dark);
+  color: var(--light);
 }
 
 .setting-toggle__label {
-    color: var(--dark-light);
+  color: var(--dark-light);
 }
 
 .react-toggle--checked .react-toggle-track {
-    background-color: var(--accent);
+  background-color: var(--accent);
 }
 
 .react-toggle--checked:is(:hover,:focus-within):not(.react-toggle--disabled) .react-toggle-track {
-    background-color: var(--accent) !important;
+  background-color: var(--accent) !important;
 }
 
 .react-toggle--checked .react-toggle-thumb {
-    border-color: var(--accent);
+  border-color: var(--accent);
 }
 
 .dismissable-banner {
@@ -180,167 +192,171 @@ a.mention {
 }
 
 .fa-close:before, .fa-remove:before, .fa-times:before {
-    color: var(--light);
+  color: var(--light);
 }
 
 .search__input {
-    background: var(--light-dark);
-    color: var(--medium-dark);
+  background: var(--light-dark);
+  color: var(--medium-dark);
 }
 
 .search__input:focus {
-    background: var(--light);
+  background: var(--light);
 }
 
 .search__input::placeholder {
-    color: var(--dark-light);
+  color: var(--dark-light);
 }
 
 .navigation-bar {
-    background: var(--medium-dark);
+  background: var(--medium-dark);
 }
 
 .navigation-bar a {
-    color: var(--dark-light);
+  color: var(--dark-light);
 }
 
 .status {
-    border-bottom: 4px solid var(--dark);
+  border-bottom: 4px solid var(--dark);
 }
 
 .column-header__back-button {
-    background: var(--light-dark);
-    color: var(--light);
+  background: var(--light-dark);
+  color: var(--light);
 }
 
 .column-inline-form {
-    background: var(--light-dark);
+  background: var(--light-dark);
 }
 
 .getting-started__wrapper {
-    background: var(--medium-dark);
+  background: var(--medium-dark);
 }
 
 .account__header__bar .avatar .account__avatar {
-    background: var(--medium-dark);
-    border: 2px solid var(--medium-dark);
+  background: var(--medium-dark);
+  border: 2px solid var(--medium-dark);
 }
 
 .text-btn {
-    color: var(--light);
+  color: var(--light);
 }
 
 .getting-started__trends h4 {
-    color: var(--light);
-    border-bottom: var(--light-dark);
+  color: var(--light);
+  border-bottom: var(--light-dark);
 }
 
 .trends__item__name a {
-    color: var(--light);
+  color: var(--light);
 }
 
 .trends__item__name {
-    color: var(--dark-light);
+  color: var(--dark-light);
 }
 
 .getting-started__trends .trends__item__current {
-    color: var(--light);
+  color: var(--light);
 }
 
 /* Account */
 
 .navigation-bar__profile a {
-    color: var(--light);
+  color: var(--light);
 }
 
 .account__header {
-    background: var(--light-dark);
+  background: var(--light-dark);
 }
 
 .account__header__account-note label {
-    color: var(--light);
+  color: var(--light);
 }
 
 .account__header__account-note textarea,
 .account__header__account-note textarea::placeholder {
-    color: var(--dark-light);
+  color: var(--dark-light);
 }
 
 .account__header__account-note textarea:focus {
-    background: var(--medium-dark);
-    color: var(--light);
+  background: var(--medium-dark);
+  color: var(--light);
 }
 
 .account__header__image {
-    background: var(--light-dark);
+  background: var(--light-dark);
 }
 
 .column-subheading {
-    color: var(--dark-light);
-    background: var(--light-dark);
+  color: var(--dark-light);
+  background: var(--light-dark);
 }
 
 .account__header__tabs__buttons .icon-button {
-    border: 1px solid var(--dark-light);
+  border: 1px solid var(--dark-light);
 }
 
 .icon-button:active, .icon-button:focus, .icon-button:hover {
-    color: var(--light);
+  color: var(--light);
 }
 
 .icon-button.active {
-    color: var(--accent);
+  color: var(--accent);
 }
 
 .icon-button.disabled {
-    color: var(--accent);
+  color: var(--accent);
+}
+
+.text-icon-button.active {
+  color: var(--accent);
 }
 
 .account__header__bio .account__header__fields {
-    background: var(--medium-dark);
+  background: var(--medium-dark);
 }
 
 .account__header__bio .account__header__fields dt,
 .account__header__bio .account__header__fields dd {
-    color: var(--dark-light);
+  color: var(--dark-light);
 }
 
 .account__header__bio .account__header__fields dl {
-    border-bootom-color: var(--light-dark);
+  border-bootom-color: var(--light-dark);
 }
 
 .account__header__tabs {
-    background: transparent;
+  background: transparent;
 }
 
 .account__header__tabs__name h1 small {
-    color: var(--dark-light);
+  color: var(--dark-light);
 }
 
 .account__header__extra__links a {
-    color: var(--light);
+  color: var(--light);
 }
 
 .account__header__bar {
-    border-bottom: none;
+  border-bottom: none;
 }
 
 .account {
-    border-bottom: 4px solid var(--dark);
+  border-bottom: 4px solid var(--dark);
 }
 
 .account__header__bio .account__header__fields a {
-    color: var(--accent);
+  color: var(--accent);
 }
 
 .account__header__bio .account__header__fields .verified a, .account__header__bio .account__header__fields .verified dd, .account__header__bio .account__header__fields .verified dt {
-    color: var(--light);
+  color: var(--light);
 }
 
 /* Navigation */
 
 .navigation-panel hr {
-    display: none;
+  display: none;
 }
 
 .navigation-panel__logo {
@@ -357,31 +373,31 @@ a.mention {
 
 .navigation-panel__logo a, 
 .navigation-panel__logo a:hover {
-    margin-bottom: 0.75rem;
-    width: 3rem;
-    height: 3rem;
-    background: none;
-    background-image: url('https://cdn.shopify.com/s/files/1/0614/6565/7577/files/mammoth-logo.svg');
-    background-repeat: no-repeat;
-    background-size: 100% auto;
+  margin-bottom: 0.75rem;
+  width: 3rem;
+  height: 3rem;
+  background: none;
+  background-image: url('https://cdn.shopify.com/s/files/1/0614/6565/7577/files/mammoth-logo.svg');
+  background-repeat: no-repeat;
+  background-size: 100% auto;
 }
 
 .column-link {
-    background: var(--medium-dark);
-    color: var(--light);
+  background: var(--medium-dark);
+  color: var(--light);
 }
 
 .column-link--transparent {
-    color: var(--medium-light);
+  color: var(--medium-light);
 }
 
 .column-link--transparent:hover {
-    color: var(--light);
+  color: var(--light);
 }
 
 .column-link:active, .column-link:focus, .column-link:hover {
-    background: none;
-    color: var(--accent);
+  background: none;
+  color: var(--accent);
 }
 
 .column-link--transparent.active {
@@ -390,28 +406,28 @@ a.mention {
 }
 
 .icon-with-badge__badge {
-    background: var(--accent);
-    border: 2px solid var(--dark);
+  background: var(--accent);
+  border: 2px solid var(--dark);
 }
 
 .column-header.active .column-header__icon {
-    color: var(--accent);
-    text-shadow: 0 0 10px rgb( 244 88 0 / 40%);
+  color: var(--accent);
+  text-shadow: 0 0 10px rgb( 244 88 0 / 40%);
 }
 
 .column-header__wrapper.active {
-    box-shadow: 0 1px 0 rgb( 0 0 0 / 100%);
+  box-shadow: 0 1px 0 rgb( 0 0 0 / 100%);
 }
 
 .column-header__wrapper.active:before {
-    background: none;
+  background: none;
 }
 
 /* Links */
 
 .status__display-name,
 .display-name__account {
-    color: var(--dark-light);
+  color: var(--dark-light);
 }
 
 .status__relative-time {
@@ -419,134 +435,238 @@ a.mention {
 }
 
 .icon-button {
-    color: var(--accent);
+  color: var(--accent);
 }
 
 .icon-button:hover {
-    color: var(--light);
+  color: var(--light);
+}
+
+button.icon-button.inverted.active {
+  color: var(--accent);
 }
 
 button.icon-button i.fa-retweet {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='22' height='209'%3E%3Cpath d='M4.97 3.16c-.1.03-.17.1-.22.18L.8 8.24c-.2.3.03.78.4.8H3.6v2.68c0 4.26-.55 3.62 3.66 3.62h7.66l-2.3-2.84c-.03-.02-.03-.04-.05-.06H7.27c-.44 0-.72-.3-.72-.72v-2.7h2.5c.37.03.63-.48.4-.77L5.5 3.35c-.12-.17-.34-.25-.53-.2zm12.16.43c-.55-.02-1.32.02-2.4.02H7.1l2.32 2.85.03.06h5.25c.42 0 .72.28.72.72v2.7h-2.5c-.36.02-.56.54-.3.8l3.92 4.9c.18.25.6.25.78 0l3.94-4.9c.26-.28 0-.83-.37-.8H18.4v-2.7c0-3.15.4-3.62-1.25-3.66z' fill='%233F8FF5' stroke-width='0'/%3E%3Cpath d='M7.78 19.66c-.24.02-.44.25-.44.5v2.46h-.06c-1.08 0-1.86-.03-2.4-.03-1.64 0-1.25.43-1.25 3.65v4.47c0 4.26-.56 3.62 3.65 3.62H8.5l-1.3-1.06c-.1-.08-.18-.2-.2-.3-.02-.17.06-.35.2-.45l1.33-1.1H7.28c-.44 0-.72-.3-.72-.7v-4.48c0-.44.28-.72.72-.72h.06v2.5c0 .38.54.63.82.38l4.9-3.93c.25-.18.25-.6 0-.78l-4.9-3.92c-.1-.1-.24-.14-.38-.12zm9.34 2.93c-.54-.02-1.3.02-2.4.02h-1.25l1.3 1.07c.1.07.18.2.2.33.02.16-.06.3-.2.4l-1.33 1.1h1.28c.42 0 .72.28.72.72v4.47c0 .42-.3.72-.72.72h-.1v-2.47c0-.3-.3-.53-.6-.47-.07 0-.14.05-.2.1l-4.9 3.93c-.26.18-.26.6 0 .78l4.9 3.92c.27.25.82 0 .8-.38v-2.5h.1c4.27 0 3.65.67 3.65-3.62v-4.47c0-3.15.4-3.62-1.25-3.66zM10.34 38.66c-.24.02-.44.25-.43.5v2.47H7.3c-1.08 0-1.86-.04-2.4-.04-1.64 0-1.25.43-1.25 3.65v4.47c0 3.66-.23 3.7 2.34 3.66l-1.34-1.1c-.1-.08-.18-.2-.2-.3 0-.17.07-.35.2-.45l1.96-1.6c-.03-.06-.04-.13-.04-.2v-4.48c0-.44.28-.72.72-.72H9.9v2.5c0 .36.5.6.8.38l4.93-3.93c.24-.18.24-.6 0-.78l-4.94-3.92c-.1-.08-.23-.13-.36-.12zm5.63 2.93l1.34 1.1c.1.07.18.2.2.33.02.16-.03.3-.16.4l-1.96 1.6c.02.07.06.13.06.22v4.47c0 .42-.3.72-.72.72h-2.66v-2.47c0-.3-.3-.53-.6-.47-.06.02-.12.05-.18.1l-4.94 3.93c-.24.18-.24.6 0 .78l4.94 3.92c.28.22.78-.02.78-.38v-2.5h2.66c4.27 0 3.65.67 3.65-3.62v-4.47c0-3.66.34-3.7-2.4-3.66zM13.06 57.66c-.23.03-.4.26-.4.5v2.47H7.28c-1.08 0-1.86-.04-2.4-.04-1.64 0-1.25.43-1.25 3.65v4.87l2.93-2.37v-2.5c0-.44.28-.72.72-.72h5.38v2.5c0 .36.5.6.78.38l4.94-3.93c.24-.18.24-.6 0-.78l-4.94-3.92c-.1-.1-.24-.14-.38-.12zm5.3 6.15l-2.92 2.4v2.52c0 .42-.3.72-.72.72h-5.4v-2.47c0-.3-.32-.53-.6-.47-.07.02-.13.05-.2.1L3.6 70.52c-.25.18-.25.6 0 .78l4.93 3.92c.28.22.78-.02.78-.38v-2.5h5.42c4.27 0 3.65.67 3.65-3.62v-4.47-.44zM19.25 78.8c-.1.03-.2.1-.28.17l-.9.9c-.44-.3-1.36-.25-3.35-.25H7.28c-1.08 0-1.86-.03-2.4-.03-1.64 0-1.25.43-1.25 3.65v.7l2.93.3v-1c0-.44.28-.72.72-.72h7.44c.2 0 .37.08.5.2l-1.8 1.8c-.25.26-.08.76.27.8l6.27.7c.28.03.56-.25.53-.53l-.7-6.25c0-.27-.3-.48-.55-.44zm-17.2 6.1c-.2.07-.36.3-.33.54l.7 6.25c.02.36.58.55.83.27l.8-.8c.02 0 .04-.02.04 0 .46.24 1.37.17 3.18.17h7.44c4.27 0 3.65.67 3.65-3.62v-.75l-2.93-.3v1.05c0 .42-.3.72-.72.72H7.28c-.15 0-.3-.03-.4-.1L8.8 86.4c.3-.24.1-.8-.27-.84l-6.28-.65h-.2zM4.88 98.6c-1.33 0-1.34.48-1.3 2.3l1.14-1.37c.08-.1.22-.17.34-.2.16 0 .34.08.44.2l1.66 2.03c.04 0 .07-.03.12-.03h7.44c.34 0 .57.2.65.5h-2.43c-.34.05-.53.52-.3.78l3.92 4.95c.18.24.6.24.78 0l3.94-4.94c.22-.27-.02-.76-.37-.77H18.4c.02-3.9.6-3.4-3.66-3.4H7.28c-1.08 0-1.86-.04-2.4-.04zm.15 2.46c-.1.03-.2.1-.28.2l-3.94 4.9c-.2.28.03.77.4.78H3.6c-.02 3.94-.45 3.4 3.66 3.4h7.44c3.65 0 3.74.3 3.7-2.25l-1.1 1.34c-.1.1-.2.17-.32.2-.16 0-.34-.08-.44-.2l-1.65-2.03c-.06.02-.1.04-.18.04H7.28c-.35 0-.57-.2-.66-.5h2.44c.37 0 .63-.5.4-.78l-3.96-4.9c-.1-.15-.3-.23-.47-.2zM4.88 117.6c-1.16 0-1.3.3-1.3 1.56l1.14-1.38c.08-.1.22-.14.34-.16.16 0 .34.04.44.16l2.22 2.75h7c.42 0 .72.28.72.72v.53h-2.6c-.3.1-.43.54-.2.78l3.92 4.9c.18.25.6.25.78 0l3.94-4.9c.22-.28-.02-.77-.37-.78H18.4v-.53c0-4.2.72-3.63-3.66-3.63H7.28c-1.08 0-1.86-.03-2.4-.03zm.1 1.74c-.1.03-.17.1-.23.16L.8 124.44c-.2.28.03.77.4.78H3.6v.5c0 4.26-.55 3.62 3.66 3.62h7.44c1.03 0 1.74.02 2.28 0-.16.02-.34-.03-.44-.15l-2.22-2.76H7.28c-.44 0-.72-.3-.72-.72v-.5h2.5c.37.02.63-.5.4-.78L5.5 119.5c-.12-.15-.34-.22-.53-.16zm12.02 10c1.2-.02 1.4-.25 1.4-1.53l-1.1 1.36c-.07.1-.17.17-.3.18zM5.94 136.6l2.37 2.93h6.42c.42 0 .72.28.72.72v1.25h-2.6c-.3.1-.43.54-.2.78l3.92 4.9c.18.25.6.25.78 0l3.94-4.9c.22-.28-.02-.77-.37-.78H18.4v-1.25c0-4.2.72-3.63-3.66-3.63H7.28c-.6 0-.92-.02-1.34-.03zm-1.72.06c-.4.08-.54.3-.6.75l.6-.74zm.84.93c-.12 0-.24.08-.3.18l-3.95 4.9c-.24.3 0 .83.4.82H3.6v1.22c0 4.26-.55 3.62 3.66 3.62h7.44c.63 0 .97.02 1.4.03l-2.37-2.93H7.28c-.44 0-.72-.3-.72-.72v-1.22h2.5c.4.04.67-.53.4-.8l-3.96-4.92c-.1-.13-.27-.2-.44-.2zm13.28 10.03l-.56.7c.36-.07.5-.3.56-.7zM17.13 155.6c-.55-.02-1.32.03-2.4.03h-8.2l2.38 2.9h5.82c.42 0 .72.28.72.72v1.97H12.9c-.32.06-.48.52-.28.78l3.94 4.94c.2.23.6.22.78-.03l3.94-4.9c.22-.28-.02-.77-.37-.78H18.4v-1.97c0-3.15.4-3.62-1.25-3.66zm-12.1.28c-.1.02-.2.1-.28.18l-3.94 4.9c-.2.3.03.78.4.8H3.6v1.96c0 4.26-.55 3.62 3.66 3.62h8.24l-2.36-2.9H7.28c-.44 0-.72-.3-.72-.72v-1.97h2.5c.37.02.63-.5.4-.78l-3.96-4.9c-.1-.15-.3-.22-.47-.2zM5.13 174.5c-.15 0-.3.07-.38.2L.8 179.6c-.24.27 0 .82.4.8H3.6v2.32c0 4.26-.55 3.62 3.66 3.62h7.94l-2.35-2.9h-5.6c-.43 0-.7-.3-.7-.72v-2.3h2.5c.38.03.66-.54.4-.83l-3.97-4.9c-.1-.13-.23-.2-.38-.2zm12 .1c-.55-.02-1.32.03-2.4.03H6.83l2.35 2.9h5.52c.42 0 .72.28.72.72v2.34h-2.6c-.3.1-.43.53-.2.78l3.92 4.9c.18.24.6.24.78 0l3.94-4.9c.22-.3-.02-.78-.37-.8H18.4v-2.33c0-3.15.4-3.62-1.25-3.66zM4.97 193.16c-.1.03-.17.1-.22.18l-3.94 4.9c-.2.3.03.78.4.8H3.6v2.68c0 4.26-.55 3.62 3.66 3.62h7.66l-2.3-2.84c-.03-.02-.03-.04-.05-.06H7.27c-.44 0-.72-.3-.72-.72v-2.7h2.5c.37.03.63-.48.4-.77l-3.96-4.9c-.12-.17-.34-.25-.53-.2zm12.16.43c-.55-.02-1.32.03-2.4.03H7.1l2.32 2.84.03.06h5.25c.42 0 .72.28.72.72v2.7h-2.5c-.36.02-.56.54-.3.8l3.92 4.9c.18.25.6.25.78 0l3.94-4.9c.26-.28 0-.83-.37-.8H18.4v-2.7c0-3.15.4-3.62-1.25-3.66z' fill='%233F8FF5' stroke-width='0'/%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='22' height='209'%3E%3Cpath d='M4.97 3.16c-.1.03-.17.1-.22.18L.8 8.24c-.2.3.03.78.4.8H3.6v2.68c0 4.26-.55 3.62 3.66 3.62h7.66l-2.3-2.84c-.03-.02-.03-.04-.05-.06H7.27c-.44 0-.72-.3-.72-.72v-2.7h2.5c.37.03.63-.48.4-.77L5.5 3.35c-.12-.17-.34-.25-.53-.2zm12.16.43c-.55-.02-1.32.02-2.4.02H7.1l2.32 2.85.03.06h5.25c.42 0 .72.28.72.72v2.7h-2.5c-.36.02-.56.54-.3.8l3.92 4.9c.18.25.6.25.78 0l3.94-4.9c.26-.28 0-.83-.37-.8H18.4v-2.7c0-3.15.4-3.62-1.25-3.66z' fill='%233F8FF5' stroke-width='0'/%3E%3Cpath d='M7.78 19.66c-.24.02-.44.25-.44.5v2.46h-.06c-1.08 0-1.86-.03-2.4-.03-1.64 0-1.25.43-1.25 3.65v4.47c0 4.26-.56 3.62 3.65 3.62H8.5l-1.3-1.06c-.1-.08-.18-.2-.2-.3-.02-.17.06-.35.2-.45l1.33-1.1H7.28c-.44 0-.72-.3-.72-.7v-4.48c0-.44.28-.72.72-.72h.06v2.5c0 .38.54.63.82.38l4.9-3.93c.25-.18.25-.6 0-.78l-4.9-3.92c-.1-.1-.24-.14-.38-.12zm9.34 2.93c-.54-.02-1.3.02-2.4.02h-1.25l1.3 1.07c.1.07.18.2.2.33.02.16-.06.3-.2.4l-1.33 1.1h1.28c.42 0 .72.28.72.72v4.47c0 .42-.3.72-.72.72h-.1v-2.47c0-.3-.3-.53-.6-.47-.07 0-.14.05-.2.1l-4.9 3.93c-.26.18-.26.6 0 .78l4.9 3.92c.27.25.82 0 .8-.38v-2.5h.1c4.27 0 3.65.67 3.65-3.62v-4.47c0-3.15.4-3.62-1.25-3.66zM10.34 38.66c-.24.02-.44.25-.43.5v2.47H7.3c-1.08 0-1.86-.04-2.4-.04-1.64 0-1.25.43-1.25 3.65v4.47c0 3.66-.23 3.7 2.34 3.66l-1.34-1.1c-.1-.08-.18-.2-.2-.3 0-.17.07-.35.2-.45l1.96-1.6c-.03-.06-.04-.13-.04-.2v-4.48c0-.44.28-.72.72-.72H9.9v2.5c0 .36.5.6.8.38l4.93-3.93c.24-.18.24-.6 0-.78l-4.94-3.92c-.1-.08-.23-.13-.36-.12zm5.63 2.93l1.34 1.1c.1.07.18.2.2.33.02.16-.03.3-.16.4l-1.96 1.6c.02.07.06.13.06.22v4.47c0 .42-.3.72-.72.72h-2.66v-2.47c0-.3-.3-.53-.6-.47-.06.02-.12.05-.18.1l-4.94 3.93c-.24.18-.24.6 0 .78l4.94 3.92c.28.22.78-.02.78-.38v-2.5h2.66c4.27 0 3.65.67 3.65-3.62v-4.47c0-3.66.34-3.7-2.4-3.66zM13.06 57.66c-.23.03-.4.26-.4.5v2.47H7.28c-1.08 0-1.86-.04-2.4-.04-1.64 0-1.25.43-1.25 3.65v4.87l2.93-2.37v-2.5c0-.44.28-.72.72-.72h5.38v2.5c0 .36.5.6.78.38l4.94-3.93c.24-.18.24-.6 0-.78l-4.94-3.92c-.1-.1-.24-.14-.38-.12zm5.3 6.15l-2.92 2.4v2.52c0 .42-.3.72-.72.72h-5.4v-2.47c0-.3-.32-.53-.6-.47-.07.02-.13.05-.2.1L3.6 70.52c-.25.18-.25.6 0 .78l4.93 3.92c.28.22.78-.02.78-.38v-2.5h5.42c4.27 0 3.65.67 3.65-3.62v-4.47-.44zM19.25 78.8c-.1.03-.2.1-.28.17l-.9.9c-.44-.3-1.36-.25-3.35-.25H7.28c-1.08 0-1.86-.03-2.4-.03-1.64 0-1.25.43-1.25 3.65v.7l2.93.3v-1c0-.44.28-.72.72-.72h7.44c.2 0 .37.08.5.2l-1.8 1.8c-.25.26-.08.76.27.8l6.27.7c.28.03.56-.25.53-.53l-.7-6.25c0-.27-.3-.48-.55-.44zm-17.2 6.1c-.2.07-.36.3-.33.54l.7 6.25c.02.36.58.55.83.27l.8-.8c.02 0 .04-.02.04 0 .46.24 1.37.17 3.18.17h7.44c4.27 0 3.65.67 3.65-3.62v-.75l-2.93-.3v1.05c0 .42-.3.72-.72.72H7.28c-.15 0-.3-.03-.4-.1L8.8 86.4c.3-.24.1-.8-.27-.84l-6.28-.65h-.2zM4.88 98.6c-1.33 0-1.34.48-1.3 2.3l1.14-1.37c.08-.1.22-.17.34-.2.16 0 .34.08.44.2l1.66 2.03c.04 0 .07-.03.12-.03h7.44c.34 0 .57.2.65.5h-2.43c-.34.05-.53.52-.3.78l3.92 4.95c.18.24.6.24.78 0l3.94-4.94c.22-.27-.02-.76-.37-.77H18.4c.02-3.9.6-3.4-3.66-3.4H7.28c-1.08 0-1.86-.04-2.4-.04zm.15 2.46c-.1.03-.2.1-.28.2l-3.94 4.9c-.2.28.03.77.4.78H3.6c-.02 3.94-.45 3.4 3.66 3.4h7.44c3.65 0 3.74.3 3.7-2.25l-1.1 1.34c-.1.1-.2.17-.32.2-.16 0-.34-.08-.44-.2l-1.65-2.03c-.06.02-.1.04-.18.04H7.28c-.35 0-.57-.2-.66-.5h2.44c.37 0 .63-.5.4-.78l-3.96-4.9c-.1-.15-.3-.23-.47-.2zM4.88 117.6c-1.16 0-1.3.3-1.3 1.56l1.14-1.38c.08-.1.22-.14.34-.16.16 0 .34.04.44.16l2.22 2.75h7c.42 0 .72.28.72.72v.53h-2.6c-.3.1-.43.54-.2.78l3.92 4.9c.18.25.6.25.78 0l3.94-4.9c.22-.28-.02-.77-.37-.78H18.4v-.53c0-4.2.72-3.63-3.66-3.63H7.28c-1.08 0-1.86-.03-2.4-.03zm.1 1.74c-.1.03-.17.1-.23.16L.8 124.44c-.2.28.03.77.4.78H3.6v.5c0 4.26-.55 3.62 3.66 3.62h7.44c1.03 0 1.74.02 2.28 0-.16.02-.34-.03-.44-.15l-2.22-2.76H7.28c-.44 0-.72-.3-.72-.72v-.5h2.5c.37.02.63-.5.4-.78L5.5 119.5c-.12-.15-.34-.22-.53-.16zm12.02 10c1.2-.02 1.4-.25 1.4-1.53l-1.1 1.36c-.07.1-.17.17-.3.18zM5.94 136.6l2.37 2.93h6.42c.42 0 .72.28.72.72v1.25h-2.6c-.3.1-.43.54-.2.78l3.92 4.9c.18.25.6.25.78 0l3.94-4.9c.22-.28-.02-.77-.37-.78H18.4v-1.25c0-4.2.72-3.63-3.66-3.63H7.28c-.6 0-.92-.02-1.34-.03zm-1.72.06c-.4.08-.54.3-.6.75l.6-.74zm.84.93c-.12 0-.24.08-.3.18l-3.95 4.9c-.24.3 0 .83.4.82H3.6v1.22c0 4.26-.55 3.62 3.66 3.62h7.44c.63 0 .97.02 1.4.03l-2.37-2.93H7.28c-.44 0-.72-.3-.72-.72v-1.22h2.5c.4.04.67-.53.4-.8l-3.96-4.92c-.1-.13-.27-.2-.44-.2zm13.28 10.03l-.56.7c.36-.07.5-.3.56-.7zM17.13 155.6c-.55-.02-1.32.03-2.4.03h-8.2l2.38 2.9h5.82c.42 0 .72.28.72.72v1.97H12.9c-.32.06-.48.52-.28.78l3.94 4.94c.2.23.6.22.78-.03l3.94-4.9c.22-.28-.02-.77-.37-.78H18.4v-1.97c0-3.15.4-3.62-1.25-3.66zm-12.1.28c-.1.02-.2.1-.28.18l-3.94 4.9c-.2.3.03.78.4.8H3.6v1.96c0 4.26-.55 3.62 3.66 3.62h8.24l-2.36-2.9H7.28c-.44 0-.72-.3-.72-.72v-1.97h2.5c.37.02.63-.5.4-.78l-3.96-4.9c-.1-.15-.3-.22-.47-.2zM5.13 174.5c-.15 0-.3.07-.38.2L.8 179.6c-.24.27 0 .82.4.8H3.6v2.32c0 4.26-.55 3.62 3.66 3.62h7.94l-2.35-2.9h-5.6c-.43 0-.7-.3-.7-.72v-2.3h2.5c.38.03.66-.54.4-.83l-3.97-4.9c-.1-.13-.23-.2-.38-.2zm12 .1c-.55-.02-1.32.03-2.4.03H6.83l2.35 2.9h5.52c.42 0 .72.28.72.72v2.34h-2.6c-.3.1-.43.53-.2.78l3.92 4.9c.18.24.6.24.78 0l3.94-4.9c.22-.3-.02-.78-.37-.8H18.4v-2.33c0-3.15.4-3.62-1.25-3.66zM4.97 193.16c-.1.03-.17.1-.22.18l-3.94 4.9c-.2.3.03.78.4.8H3.6v2.68c0 4.26-.55 3.62 3.66 3.62h7.66l-2.3-2.84c-.03-.02-.03-.04-.05-.06H7.27c-.44 0-.72-.3-.72-.72v-2.7h2.5c.37.03.63-.48.4-.77l-3.96-4.9c-.12-.17-.34-.25-.53-.2zm12.16.43c-.55-.02-1.32.03-2.4.03H7.1l2.32 2.84.03.06h5.25c.42 0 .72.28.72.72v2.7h-2.5c-.36.02-.56.54-.3.8l3.92 4.9c.18.25.6.25.78 0l3.94-4.9c.26-.28 0-.83-.37-.8H18.4v-2.7c0-3.15.4-3.62-1.25-3.66z' fill='%233F8FF5' stroke-width='0'/%3E%3C/svg%3E");
 }
 
 button.icon-button i.fa-retweet:hover {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='22' height='209'%3E%3Cpath d='M4.97 3.16c-.1.03-.17.1-.22.18L.8 8.24c-.2.3.03.78.4.8H3.6v2.68c0 4.26-.55 3.62 3.66 3.62h7.66l-2.3-2.84c-.03-.02-.03-.04-.05-.06H7.27c-.44 0-.72-.3-.72-.72v-2.7h2.5c.37.03.63-.48.4-.77L5.5 3.35c-.12-.17-.34-.25-.53-.2zm12.16.43c-.55-.02-1.32.02-2.4.02H7.1l2.32 2.85.03.06h5.25c.42 0 .72.28.72.72v2.7h-2.5c-.36.02-.56.54-.3.8l3.92 4.9c.18.25.6.25.78 0l3.94-4.9c.26-.28 0-.83-.37-.8H18.4v-2.7c0-3.15.4-3.62-1.25-3.66z' fill='%23ffffff' stroke-width='0'/%3E%3Cpath d='M7.78 19.66c-.24.02-.44.25-.44.5v2.46h-.06c-1.08 0-1.86-.03-2.4-.03-1.64 0-1.25.43-1.25 3.65v4.47c0 4.26-.56 3.62 3.65 3.62H8.5l-1.3-1.06c-.1-.08-.18-.2-.2-.3-.02-.17.06-.35.2-.45l1.33-1.1H7.28c-.44 0-.72-.3-.72-.7v-4.48c0-.44.28-.72.72-.72h.06v2.5c0 .38.54.63.82.38l4.9-3.93c.25-.18.25-.6 0-.78l-4.9-3.92c-.1-.1-.24-.14-.38-.12zm9.34 2.93c-.54-.02-1.3.02-2.4.02h-1.25l1.3 1.07c.1.07.18.2.2.33.02.16-.06.3-.2.4l-1.33 1.1h1.28c.42 0 .72.28.72.72v4.47c0 .42-.3.72-.72.72h-.1v-2.47c0-.3-.3-.53-.6-.47-.07 0-.14.05-.2.1l-4.9 3.93c-.26.18-.26.6 0 .78l4.9 3.92c.27.25.82 0 .8-.38v-2.5h.1c4.27 0 3.65.67 3.65-3.62v-4.47c0-3.15.4-3.62-1.25-3.66zM10.34 38.66c-.24.02-.44.25-.43.5v2.47H7.3c-1.08 0-1.86-.04-2.4-.04-1.64 0-1.25.43-1.25 3.65v4.47c0 3.66-.23 3.7 2.34 3.66l-1.34-1.1c-.1-.08-.18-.2-.2-.3 0-.17.07-.35.2-.45l1.96-1.6c-.03-.06-.04-.13-.04-.2v-4.48c0-.44.28-.72.72-.72H9.9v2.5c0 .36.5.6.8.38l4.93-3.93c.24-.18.24-.6 0-.78l-4.94-3.92c-.1-.08-.23-.13-.36-.12zm5.63 2.93l1.34 1.1c.1.07.18.2.2.33.02.16-.03.3-.16.4l-1.96 1.6c.02.07.06.13.06.22v4.47c0 .42-.3.72-.72.72h-2.66v-2.47c0-.3-.3-.53-.6-.47-.06.02-.12.05-.18.1l-4.94 3.93c-.24.18-.24.6 0 .78l4.94 3.92c.28.22.78-.02.78-.38v-2.5h2.66c4.27 0 3.65.67 3.65-3.62v-4.47c0-3.66.34-3.7-2.4-3.66zM13.06 57.66c-.23.03-.4.26-.4.5v2.47H7.28c-1.08 0-1.86-.04-2.4-.04-1.64 0-1.25.43-1.25 3.65v4.87l2.93-2.37v-2.5c0-.44.28-.72.72-.72h5.38v2.5c0 .36.5.6.78.38l4.94-3.93c.24-.18.24-.6 0-.78l-4.94-3.92c-.1-.1-.24-.14-.38-.12zm5.3 6.15l-2.92 2.4v2.52c0 .42-.3.72-.72.72h-5.4v-2.47c0-.3-.32-.53-.6-.47-.07.02-.13.05-.2.1L3.6 70.52c-.25.18-.25.6 0 .78l4.93 3.92c.28.22.78-.02.78-.38v-2.5h5.42c4.27 0 3.65.67 3.65-3.62v-4.47-.44zM19.25 78.8c-.1.03-.2.1-.28.17l-.9.9c-.44-.3-1.36-.25-3.35-.25H7.28c-1.08 0-1.86-.03-2.4-.03-1.64 0-1.25.43-1.25 3.65v.7l2.93.3v-1c0-.44.28-.72.72-.72h7.44c.2 0 .37.08.5.2l-1.8 1.8c-.25.26-.08.76.27.8l6.27.7c.28.03.56-.25.53-.53l-.7-6.25c0-.27-.3-.48-.55-.44zm-17.2 6.1c-.2.07-.36.3-.33.54l.7 6.25c.02.36.58.55.83.27l.8-.8c.02 0 .04-.02.04 0 .46.24 1.37.17 3.18.17h7.44c4.27 0 3.65.67 3.65-3.62v-.75l-2.93-.3v1.05c0 .42-.3.72-.72.72H7.28c-.15 0-.3-.03-.4-.1L8.8 86.4c.3-.24.1-.8-.27-.84l-6.28-.65h-.2zM4.88 98.6c-1.33 0-1.34.48-1.3 2.3l1.14-1.37c.08-.1.22-.17.34-.2.16 0 .34.08.44.2l1.66 2.03c.04 0 .07-.03.12-.03h7.44c.34 0 .57.2.65.5h-2.43c-.34.05-.53.52-.3.78l3.92 4.95c.18.24.6.24.78 0l3.94-4.94c.22-.27-.02-.76-.37-.77H18.4c.02-3.9.6-3.4-3.66-3.4H7.28c-1.08 0-1.86-.04-2.4-.04zm.15 2.46c-.1.03-.2.1-.28.2l-3.94 4.9c-.2.28.03.77.4.78H3.6c-.02 3.94-.45 3.4 3.66 3.4h7.44c3.65 0 3.74.3 3.7-2.25l-1.1 1.34c-.1.1-.2.17-.32.2-.16 0-.34-.08-.44-.2l-1.65-2.03c-.06.02-.1.04-.18.04H7.28c-.35 0-.57-.2-.66-.5h2.44c.37 0 .63-.5.4-.78l-3.96-4.9c-.1-.15-.3-.23-.47-.2zM4.88 117.6c-1.16 0-1.3.3-1.3 1.56l1.14-1.38c.08-.1.22-.14.34-.16.16 0 .34.04.44.16l2.22 2.75h7c.42 0 .72.28.72.72v.53h-2.6c-.3.1-.43.54-.2.78l3.92 4.9c.18.25.6.25.78 0l3.94-4.9c.22-.28-.02-.77-.37-.78H18.4v-.53c0-4.2.72-3.63-3.66-3.63H7.28c-1.08 0-1.86-.03-2.4-.03zm.1 1.74c-.1.03-.17.1-.23.16L.8 124.44c-.2.28.03.77.4.78H3.6v.5c0 4.26-.55 3.62 3.66 3.62h7.44c1.03 0 1.74.02 2.28 0-.16.02-.34-.03-.44-.15l-2.22-2.76H7.28c-.44 0-.72-.3-.72-.72v-.5h2.5c.37.02.63-.5.4-.78L5.5 119.5c-.12-.15-.34-.22-.53-.16zm12.02 10c1.2-.02 1.4-.25 1.4-1.53l-1.1 1.36c-.07.1-.17.17-.3.18zM5.94 136.6l2.37 2.93h6.42c.42 0 .72.28.72.72v1.25h-2.6c-.3.1-.43.54-.2.78l3.92 4.9c.18.25.6.25.78 0l3.94-4.9c.22-.28-.02-.77-.37-.78H18.4v-1.25c0-4.2.72-3.63-3.66-3.63H7.28c-.6 0-.92-.02-1.34-.03zm-1.72.06c-.4.08-.54.3-.6.75l.6-.74zm.84.93c-.12 0-.24.08-.3.18l-3.95 4.9c-.24.3 0 .83.4.82H3.6v1.22c0 4.26-.55 3.62 3.66 3.62h7.44c.63 0 .97.02 1.4.03l-2.37-2.93H7.28c-.44 0-.72-.3-.72-.72v-1.22h2.5c.4.04.67-.53.4-.8l-3.96-4.92c-.1-.13-.27-.2-.44-.2zm13.28 10.03l-.56.7c.36-.07.5-.3.56-.7zM17.13 155.6c-.55-.02-1.32.03-2.4.03h-8.2l2.38 2.9h5.82c.42 0 .72.28.72.72v1.97H12.9c-.32.06-.48.52-.28.78l3.94 4.94c.2.23.6.22.78-.03l3.94-4.9c.22-.28-.02-.77-.37-.78H18.4v-1.97c0-3.15.4-3.62-1.25-3.66zm-12.1.28c-.1.02-.2.1-.28.18l-3.94 4.9c-.2.3.03.78.4.8H3.6v1.96c0 4.26-.55 3.62 3.66 3.62h8.24l-2.36-2.9H7.28c-.44 0-.72-.3-.72-.72v-1.97h2.5c.37.02.63-.5.4-.78l-3.96-4.9c-.1-.15-.3-.22-.47-.2zM5.13 174.5c-.15 0-.3.07-.38.2L.8 179.6c-.24.27 0 .82.4.8H3.6v2.32c0 4.26-.55 3.62 3.66 3.62h7.94l-2.35-2.9h-5.6c-.43 0-.7-.3-.7-.72v-2.3h2.5c.38.03.66-.54.4-.83l-3.97-4.9c-.1-.13-.23-.2-.38-.2zm12 .1c-.55-.02-1.32.03-2.4.03H6.83l2.35 2.9h5.52c.42 0 .72.28.72.72v2.34h-2.6c-.3.1-.43.53-.2.78l3.92 4.9c.18.24.6.24.78 0l3.94-4.9c.22-.3-.02-.78-.37-.8H18.4v-2.33c0-3.15.4-3.62-1.25-3.66zM4.97 193.16c-.1.03-.17.1-.22.18l-3.94 4.9c-.2.3.03.78.4.8H3.6v2.68c0 4.26-.55 3.62 3.66 3.62h7.66l-2.3-2.84c-.03-.02-.03-.04-.05-.06H7.27c-.44 0-.72-.3-.72-.72v-2.7h2.5c.37.03.63-.48.4-.77l-3.96-4.9c-.12-.17-.34-.25-.53-.2zm12.16.43c-.55-.02-1.32.03-2.4.03H7.1l2.32 2.84.03.06h5.25c.42 0 .72.28.72.72v2.7h-2.5c-.36.02-.56.54-.3.8l3.92 4.9c.18.25.6.25.78 0l3.94-4.9c.26-.28 0-.83-.37-.8H18.4v-2.7c0-3.15.4-3.62-1.25-3.66z' fill='%23ffffff' stroke-width='0'/%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='22' height='209'%3E%3Cpath d='M4.97 3.16c-.1.03-.17.1-.22.18L.8 8.24c-.2.3.03.78.4.8H3.6v2.68c0 4.26-.55 3.62 3.66 3.62h7.66l-2.3-2.84c-.03-.02-.03-.04-.05-.06H7.27c-.44 0-.72-.3-.72-.72v-2.7h2.5c.37.03.63-.48.4-.77L5.5 3.35c-.12-.17-.34-.25-.53-.2zm12.16.43c-.55-.02-1.32.02-2.4.02H7.1l2.32 2.85.03.06h5.25c.42 0 .72.28.72.72v2.7h-2.5c-.36.02-.56.54-.3.8l3.92 4.9c.18.25.6.25.78 0l3.94-4.9c.26-.28 0-.83-.37-.8H18.4v-2.7c0-3.15.4-3.62-1.25-3.66z' fill='%23ffffff' stroke-width='0'/%3E%3Cpath d='M7.78 19.66c-.24.02-.44.25-.44.5v2.46h-.06c-1.08 0-1.86-.03-2.4-.03-1.64 0-1.25.43-1.25 3.65v4.47c0 4.26-.56 3.62 3.65 3.62H8.5l-1.3-1.06c-.1-.08-.18-.2-.2-.3-.02-.17.06-.35.2-.45l1.33-1.1H7.28c-.44 0-.72-.3-.72-.7v-4.48c0-.44.28-.72.72-.72h.06v2.5c0 .38.54.63.82.38l4.9-3.93c.25-.18.25-.6 0-.78l-4.9-3.92c-.1-.1-.24-.14-.38-.12zm9.34 2.93c-.54-.02-1.3.02-2.4.02h-1.25l1.3 1.07c.1.07.18.2.2.33.02.16-.06.3-.2.4l-1.33 1.1h1.28c.42 0 .72.28.72.72v4.47c0 .42-.3.72-.72.72h-.1v-2.47c0-.3-.3-.53-.6-.47-.07 0-.14.05-.2.1l-4.9 3.93c-.26.18-.26.6 0 .78l4.9 3.92c.27.25.82 0 .8-.38v-2.5h.1c4.27 0 3.65.67 3.65-3.62v-4.47c0-3.15.4-3.62-1.25-3.66zM10.34 38.66c-.24.02-.44.25-.43.5v2.47H7.3c-1.08 0-1.86-.04-2.4-.04-1.64 0-1.25.43-1.25 3.65v4.47c0 3.66-.23 3.7 2.34 3.66l-1.34-1.1c-.1-.08-.18-.2-.2-.3 0-.17.07-.35.2-.45l1.96-1.6c-.03-.06-.04-.13-.04-.2v-4.48c0-.44.28-.72.72-.72H9.9v2.5c0 .36.5.6.8.38l4.93-3.93c.24-.18.24-.6 0-.78l-4.94-3.92c-.1-.08-.23-.13-.36-.12zm5.63 2.93l1.34 1.1c.1.07.18.2.2.33.02.16-.03.3-.16.4l-1.96 1.6c.02.07.06.13.06.22v4.47c0 .42-.3.72-.72.72h-2.66v-2.47c0-.3-.3-.53-.6-.47-.06.02-.12.05-.18.1l-4.94 3.93c-.24.18-.24.6 0 .78l4.94 3.92c.28.22.78-.02.78-.38v-2.5h2.66c4.27 0 3.65.67 3.65-3.62v-4.47c0-3.66.34-3.7-2.4-3.66zM13.06 57.66c-.23.03-.4.26-.4.5v2.47H7.28c-1.08 0-1.86-.04-2.4-.04-1.64 0-1.25.43-1.25 3.65v4.87l2.93-2.37v-2.5c0-.44.28-.72.72-.72h5.38v2.5c0 .36.5.6.78.38l4.94-3.93c.24-.18.24-.6 0-.78l-4.94-3.92c-.1-.1-.24-.14-.38-.12zm5.3 6.15l-2.92 2.4v2.52c0 .42-.3.72-.72.72h-5.4v-2.47c0-.3-.32-.53-.6-.47-.07.02-.13.05-.2.1L3.6 70.52c-.25.18-.25.6 0 .78l4.93 3.92c.28.22.78-.02.78-.38v-2.5h5.42c4.27 0 3.65.67 3.65-3.62v-4.47-.44zM19.25 78.8c-.1.03-.2.1-.28.17l-.9.9c-.44-.3-1.36-.25-3.35-.25H7.28c-1.08 0-1.86-.03-2.4-.03-1.64 0-1.25.43-1.25 3.65v.7l2.93.3v-1c0-.44.28-.72.72-.72h7.44c.2 0 .37.08.5.2l-1.8 1.8c-.25.26-.08.76.27.8l6.27.7c.28.03.56-.25.53-.53l-.7-6.25c0-.27-.3-.48-.55-.44zm-17.2 6.1c-.2.07-.36.3-.33.54l.7 6.25c.02.36.58.55.83.27l.8-.8c.02 0 .04-.02.04 0 .46.24 1.37.17 3.18.17h7.44c4.27 0 3.65.67 3.65-3.62v-.75l-2.93-.3v1.05c0 .42-.3.72-.72.72H7.28c-.15 0-.3-.03-.4-.1L8.8 86.4c.3-.24.1-.8-.27-.84l-6.28-.65h-.2zM4.88 98.6c-1.33 0-1.34.48-1.3 2.3l1.14-1.37c.08-.1.22-.17.34-.2.16 0 .34.08.44.2l1.66 2.03c.04 0 .07-.03.12-.03h7.44c.34 0 .57.2.65.5h-2.43c-.34.05-.53.52-.3.78l3.92 4.95c.18.24.6.24.78 0l3.94-4.94c.22-.27-.02-.76-.37-.77H18.4c.02-3.9.6-3.4-3.66-3.4H7.28c-1.08 0-1.86-.04-2.4-.04zm.15 2.46c-.1.03-.2.1-.28.2l-3.94 4.9c-.2.28.03.77.4.78H3.6c-.02 3.94-.45 3.4 3.66 3.4h7.44c3.65 0 3.74.3 3.7-2.25l-1.1 1.34c-.1.1-.2.17-.32.2-.16 0-.34-.08-.44-.2l-1.65-2.03c-.06.02-.1.04-.18.04H7.28c-.35 0-.57-.2-.66-.5h2.44c.37 0 .63-.5.4-.78l-3.96-4.9c-.1-.15-.3-.23-.47-.2zM4.88 117.6c-1.16 0-1.3.3-1.3 1.56l1.14-1.38c.08-.1.22-.14.34-.16.16 0 .34.04.44.16l2.22 2.75h7c.42 0 .72.28.72.72v.53h-2.6c-.3.1-.43.54-.2.78l3.92 4.9c.18.25.6.25.78 0l3.94-4.9c.22-.28-.02-.77-.37-.78H18.4v-.53c0-4.2.72-3.63-3.66-3.63H7.28c-1.08 0-1.86-.03-2.4-.03zm.1 1.74c-.1.03-.17.1-.23.16L.8 124.44c-.2.28.03.77.4.78H3.6v.5c0 4.26-.55 3.62 3.66 3.62h7.44c1.03 0 1.74.02 2.28 0-.16.02-.34-.03-.44-.15l-2.22-2.76H7.28c-.44 0-.72-.3-.72-.72v-.5h2.5c.37.02.63-.5.4-.78L5.5 119.5c-.12-.15-.34-.22-.53-.16zm12.02 10c1.2-.02 1.4-.25 1.4-1.53l-1.1 1.36c-.07.1-.17.17-.3.18zM5.94 136.6l2.37 2.93h6.42c.42 0 .72.28.72.72v1.25h-2.6c-.3.1-.43.54-.2.78l3.92 4.9c.18.25.6.25.78 0l3.94-4.9c.22-.28-.02-.77-.37-.78H18.4v-1.25c0-4.2.72-3.63-3.66-3.63H7.28c-.6 0-.92-.02-1.34-.03zm-1.72.06c-.4.08-.54.3-.6.75l.6-.74zm.84.93c-.12 0-.24.08-.3.18l-3.95 4.9c-.24.3 0 .83.4.82H3.6v1.22c0 4.26-.55 3.62 3.66 3.62h7.44c.63 0 .97.02 1.4.03l-2.37-2.93H7.28c-.44 0-.72-.3-.72-.72v-1.22h2.5c.4.04.67-.53.4-.8l-3.96-4.92c-.1-.13-.27-.2-.44-.2zm13.28 10.03l-.56.7c.36-.07.5-.3.56-.7zM17.13 155.6c-.55-.02-1.32.03-2.4.03h-8.2l2.38 2.9h5.82c.42 0 .72.28.72.72v1.97H12.9c-.32.06-.48.52-.28.78l3.94 4.94c.2.23.6.22.78-.03l3.94-4.9c.22-.28-.02-.77-.37-.78H18.4v-1.97c0-3.15.4-3.62-1.25-3.66zm-12.1.28c-.1.02-.2.1-.28.18l-3.94 4.9c-.2.3.03.78.4.8H3.6v1.96c0 4.26-.55 3.62 3.66 3.62h8.24l-2.36-2.9H7.28c-.44 0-.72-.3-.72-.72v-1.97h2.5c.37.02.63-.5.4-.78l-3.96-4.9c-.1-.15-.3-.22-.47-.2zM5.13 174.5c-.15 0-.3.07-.38.2L.8 179.6c-.24.27 0 .82.4.8H3.6v2.32c0 4.26-.55 3.62 3.66 3.62h7.94l-2.35-2.9h-5.6c-.43 0-.7-.3-.7-.72v-2.3h2.5c.38.03.66-.54.4-.83l-3.97-4.9c-.1-.13-.23-.2-.38-.2zm12 .1c-.55-.02-1.32.03-2.4.03H6.83l2.35 2.9h5.52c.42 0 .72.28.72.72v2.34h-2.6c-.3.1-.43.53-.2.78l3.92 4.9c.18.24.6.24.78 0l3.94-4.9c.22-.3-.02-.78-.37-.8H18.4v-2.33c0-3.15.4-3.62-1.25-3.66zM4.97 193.16c-.1.03-.17.1-.22.18l-3.94 4.9c-.2.3.03.78.4.8H3.6v2.68c0 4.26-.55 3.62 3.66 3.62h7.66l-2.3-2.84c-.03-.02-.03-.04-.05-.06H7.27c-.44 0-.72-.3-.72-.72v-2.7h2.5c.37.03.63-.48.4-.77l-3.96-4.9c-.12-.17-.34-.25-.53-.2zm12.16.43c-.55-.02-1.32.03-2.4.03H7.1l2.32 2.84.03.06h5.25c.42 0 .72.28.72.72v2.7h-2.5c-.36.02-.56.54-.3.8l3.92 4.9c.18.25.6.25.78 0l3.94-4.9c.26-.28 0-.83-.37-.8H18.4v-2.7c0-3.15.4-3.62-1.25-3.66z' fill='%23ffffff' stroke-width='0'/%3E%3C/svg%3E");
 }
 
 /* Posts */
 
 .focusable:focus {
-    background: none;
+  background: none;
 }
 
 .muted .status__content, .muted .status__content a, .muted .status__content p, .muted .status__display-name strong {
-    color: var(--light);
+  color: var(--light);
 }
 
 .account__section-headline a.active, .account__section-headline button.active, .notification__filter-bar a.active, .notification__filter-bar button.active {
-    background: var(--accent);
-    color: var(--light);
+  background: var(--accent);
+  color: var(--light);
 }
 
 
 .account__section-headline a.active:after, .account__section-headline button.active:after, .notification__filter-bar a.active:after, .notification__filter-bar button.active:after {
-    border-color: transparent transparent var(--medium-dark);
+  border-color: transparent transparent var(--medium-dark);
 }
 
 .account__section-headline a.active:after, .account__section-headline a.active:before, .account__section-headline button.active:after, .account__section-headline button.active:before, .notification__filter-bar a.active:after, .notification__filter-bar a.active:before, .notification__filter-bar button.active:after, .notification__filter-bar button.active:before {
-   border-color: transparent transparent var(--medium-dark);
+  border-color: transparent transparent var(--medium-dark);
 }
 
 .account__section-headline a, .account__section-headline button, .notification__filter-bar a, .notification__filter-bar button {
-    background: var(--light-dark);
-    color: var(--dark-light);
+  background: var(--light-dark);
+  color: var(--dark-light);
 }
 
 .account__section-headline a:hover, .account__section-headline button:hover, .notification__filter-bar a:hover, .notification__filter-bar button:hover {
-    color: var(--light);
+  color: var(--light);
 }
 
 .account__section-headline, .notification__filter-bar {
-    border-bottom: none;
+  border-bottom: none;
 }
 
 .notification__message {
-    color: var(--light);
+  color: var(--light);
 }
 
 .notification.unread:before, .status__wrapper.unread:before {
-    border-left: 2px solid var(--accent);
+  border-left: 2px solid var(--accent);
 }
 
 .icon-button.star-icon.active, .notification__favourite-icon-wrapper .star-icon {
-    color: var(--color-3);
+  color: var(--color-3);
 }
 
 .status__prepend {
-    color: var(--light);
+  color: var(--light);
 }
 
 .status__prepend .status__display-name strong {
-    color: var(--light);
+  color: var(--light);
 }
 
 .notification__message .fa {
-    color: var(--light) !important;
+  color: var(--light) !important;
 }
 
 .poll__chart {
-    background: var(--light-dark);
+  background: var(--light-dark);
 }
 
 .poll__chart.leading {
-    background: var(--accent);
+  background: var(--accent);
 }
 
 .poll__link {
-    color: var(--dark-light);
+  color: var(--dark-light);
 }
 
 .poll__footer {
-    color: var(--dark-light);
+  color: var(--dark-light);
 }
 
 .poll__input {
-    border: 1px solid var(--dark-light);
+  border: 1px solid var(--dark-light);
 }
 
 .poll__input.active {
-    border-color: var(--light);
-    background: var(--accent);
+  border-color: var(--light);
+  background: var(--accent);
 }
 
 .poll__input:active, .poll__input:focus, .poll__input:hover {
-    border-color: var(--accent);
+  border-color: var(--accent);
+}
+
+.poll__option input[type=text]:focus {
+  border-color: var(--accent);
 }
 
 .unhandled-link {
-    color: var(--light) !important;
+  color: var(--light) !important;
 }
 
 .status-card,
 .status-card.compact {
-    border-color: var(--light-dark);
-    color: var(--dark-light);
+  border-color: var(--light-dark);
+  color: var(--dark-light);
 }
 
 .status-card__image {
-    background: var(--medium-dark);
+  background: var(--medium-dark);
 }
 
 .status-card__title {
-    color: var(--light);
+  color: var(--light);
 }
 
 a.status-card.compact:hover {
-    background-color: var(--light-dark);
+  background-color: var(--light-dark);
 }
 
 .reply-indicator__content .status__content__spoiler-link, .status__content .status__content__spoiler-link {
-    background: var(--light);
-    color: var(--medium-dark);
+  background: var(--light);
+  color: var(--medium-dark);
+}
+
+/* About */
+
+.about__section__title {
+  color: var(--accent);
+}
+
+/* Admin */
+
+body.admin {
+  background: var(--dark);
+}
+
+.admin-wrapper .sidebar-wrapper__inner {
+  background: var(--medium-dark);
+}
+
+.admin-wrapper .content__heading__tabs a.selected,
+.admin-wrapper .content__heading__tabs a.selected:hover {
+  background: var(--accent);
+}
+
+.admin-wrapper p a {
+  color: var(--light) !important;
+}
+
+.admin-wrapper p a:hover {
+  color: var(--accent) !important;
+}
+
+.admin-wrapper .sidebar ul .simple-navigation-active-leaf a {
+  background: var(--accent);
+}
+
+.admin-wrapper .sidebar ul .simple-navigation-active-leaf a:hover {
+  background: var(--light-accent);
+}
+
+.filters .filter-subset a.selected {
+  color: var(--accent);
+  border-bottom: 2px solid var(--accent);
+}
+
+/* Components */
+
+.dropdown-menu__item a:active,
+.dropdown-menu__item a:focus,
+.dropdown-menu__item a:hover {
+  background-color: var(--accent);
+  color: var(--light);
+}
+
+.simple_form input[type=text]:active,
+.simple_form input[type=text]:focus,
+.simple_form input[type=password]:active,
+.simple_form input[type=password]:focus,
+.simple_form textarea:active,
+.simple_form textarea:focus {
+  border-color: var(--accent);
+}
+
+.simple_form .input.boolean label a {
+  color: var(--accent);
+}
+
+.simple_form .block-button,
+.simple_form .button,
+.simple_form button {
+  background: var(--accent);
+}
+
+.simple_form .block-button:hover,
+.simple_form .block-button:active,
+.simple_form .block-button:focus,
+.simple_form .button:hover,
+.simple_form .button:active,
+.simple_form .button:focus,
+.simple_form button:hover,
+.simple_form button:active,
+.simple_form button:focus {
+  background-color: var(--light);
+  color: var(--accent);
+}
+
+
+.privacy-dropdown.active .privacy-dropdown__value.active {
+  background: var(--accent);
+}
+
+.language-dropdown__dropdown__results__item.active,
+.language-dropdown__dropdown__results__item.active:hover,
+.privacy-dropdown__option.active:hover,
+.privacy-dropdown__option.active,
+.privacy-dropdown__option:hover {
+  background: var(--accent);
 }

--- a/public/custom.css
+++ b/public/custom.css
@@ -33,6 +33,15 @@
   background: var(--medium-dark);
 }
 
+.theme-default .empty-column-indicator a,
+.theme-default .follow_requests-unlocked_explanation a {
+  color: var(--accent);
+}
+
+.theme-default .drawer__inner__mastodon {
+  background-color: var(--medium-dark);
+}
+
 .theme-default .compose-form {
   background: var(--medium-dark);
 }
@@ -43,6 +52,10 @@
 
 .theme-default .drawer__header {
   background: var(--light-dark);
+}
+
+.theme-default .drawer__tab {
+  color: var(--light);
 }
 
 .theme-default .navigation-bar {
@@ -67,6 +80,11 @@
   color: var(--light);
 }
 
+.theme-default .column-back-button {
+  background: var(--light-dark);
+  color: var(--light);
+}
+
 .theme-default .dismissable-banner {
   background: var(--medium-dark);
   border-bottom: 1px solid var(--light-dark);
@@ -86,6 +104,15 @@
 
 .theme-default .status {
   border-bottom: 10px solid var(--dark);
+}
+
+
+.theme-default .unhandled-link {
+  color: var(--light) !important;
+}
+
+.theme-default .status-card__title {
+  color: var(--light);
 }
 
 .theme-default .column-link--transparent {
@@ -130,6 +157,29 @@
   border: 2px solid var(--medium-dark);
 }
 
+.theme-default .account__header__bio .account__header__fields {
+  background: var(--medium-dark);
+}
+
+.theme-default .account__header__account-note textarea,
+.account__header__account-note textarea::placeholder {
+  color: var(--dark-light);
+}
+
+.theme-default .account__header__account-note textarea:focus {
+  background: var(--medium-dark);
+  color: var(--light);
+}
+
+.theme-default .account__header__image {
+  background: var(--light-dark);
+}
+
+.theme-default .column-subheading {
+  color: var(--dark-light);
+  background: var(--light-dark);
+}
+
 .theme-default .reply-indicator {
   background: var(--light-dark);
 }
@@ -145,6 +195,20 @@
 .theme-default .load-more:hover {
   background: var(--medium-dark);
   color: var(--accent);
+}
+
+.theme-default .getting-started__wrapper .column-link {
+  background: var(--medium-dark);
+}
+
+.theme-default .icon-button:active,
+.theme-default .icon-button:focus,
+.theme-default .icon-button:hover {
+  color: var(--light);
+}
+
+.theme-default .text-btn {
+  color: var(--light);
 }
 
 /* Account */
@@ -194,6 +258,14 @@
   border-color: transparent transparent var(--medium-dark);
 }
 
+.theme-default .account__header {
+  background: var(--light-dark);
+}
+
+.theme-default .account__header__account-note label {
+  color: var(--light);
+}
+
 .theme-default a.mention {
   color: var(--light) !important;
 }
@@ -206,6 +278,24 @@
   color: var(--light) !important;
 }
 
+.theme-default .follow_requests-unlocked_explanation {
+  background: var(--medium-dark);
+  border-bottom: 1px solid var(--light-dark);
+  color: var(--dark-light);
+}
+
+.theme-default .conversation--unread {
+  background-color: var(--light-dark);
+}
+
+.theme-default .detailed-status {
+  background-color: var(--medium-dark);
+}
+
+.theme-default .detailed-status__action-bar {
+  background-color: var(--medium-dark);
+}
+
 /* Posts */
 
 .theme-default .status__prepend {
@@ -213,6 +303,32 @@
 }
 
 .theme-default .status__prepend .status__display-name strong {
+  color: var(--light);
+}
+
+.theme-default .status-card,
+.theme-default .status-card.compact {
+  border-color: var(--light-dark);
+  color: var(--dark-light);
+}
+
+.theme-default a.status-card.compact:hover {
+  background-color: var(--light-dark);
+}
+
+.theme-default .status-card__image {
+  background: var(--medium-dark);
+}
+
+.theme-default p,
+.theme-default p a {
+  color: var(--dark-light) !important;
+}
+
+.theme-default .muted .status__content,
+.theme-default .muted .status__content a,
+.theme-default .muted .status__content p,
+.theme-default .muted .status__display-name strong {
   color: var(--light);
 }
 
@@ -307,11 +423,6 @@
   color: var(--medium-light);
 }
 
-p,
-p a {
-  color: var(--dark-light) !important;
-}
-
 /* Layout */
 
 .column > .scrollable {
@@ -324,9 +435,6 @@ p a {
 
 .drawer__header a:hover {
   background: var(--accent);
-}
-
-.drawer__tab {
   color: var(--light);
 }
 
@@ -337,7 +445,6 @@ p a {
 .drawer__inner__mastodon {
   background: none;
   background-image: none;
-  background-color: var(--medium-dark);
 }
 
 .drawer__inner__mastodon img {
@@ -345,8 +452,7 @@ p a {
 }
 
 .column-back-button {
-  background: var(--light-dark);
-  color: var(--light);
+  color: var(--accent);
 }
 
 .setting-toggle__label {
@@ -377,10 +483,6 @@ p a {
   color: var(--dark-light);
 }
 
-.text-btn {
-  color: var(--light);
-}
-
 .getting-started__trends h4 {
   color: var(--light);
   border-bottom: var(--light-dark);
@@ -399,42 +501,8 @@ p a {
 }
 
 /* Account */
-
-.account__header {
-  background: var(--light-dark);
-}
-
-.account__header__account-note label {
-  color: var(--light);
-}
-
-.account__header__account-note textarea,
-.account__header__account-note textarea::placeholder {
-  color: var(--dark-light);
-}
-
-.account__header__account-note textarea:focus {
-  background: var(--medium-dark);
-  color: var(--light);
-}
-
-.account__header__image {
-  background: var(--light-dark);
-}
-
-.column-subheading {
-  color: var(--dark-light);
-  background: var(--light-dark);
-}
-
 .account__header__tabs__buttons .icon-button {
   border: 1px solid var(--dark-light);
-}
-
-.icon-button:active,
-.icon-button:focus,
-.icon-button:hover {
-  color: var(--light);
 }
 
 .icon-button.active {
@@ -447,10 +515,6 @@ p a {
 
 .text-icon-button.active {
   color: var(--accent);
-}
-
-.account__header__bio .account__header__fields {
-  background: var(--medium-dark);
 }
 
 .account__header__bio .account__header__fields dt,
@@ -551,10 +615,6 @@ p a {
   color: var(--dark-light);
 }
 
-.icon-button:hover {
-  color: var(--light);
-}
-
 button.icon-button.inverted.active {
   color: var(--accent);
 }
@@ -571,13 +631,6 @@ button.icon-button i.fa-retweet:hover {
 
 .focusable:focus {
   background: none;
-}
-
-.muted .status__content,
-.muted .status__content a,
-.muted .status__content p,
-.muted .status__display-name strong {
-  color: var(--light);
 }
 
 .account__section-headline,
@@ -631,31 +684,28 @@ button.icon-button i.fa-retweet:hover {
 }
 
 .unhandled-link {
-  color: var(--light) !important;
+  color: var(--accent)!important;
 }
 
-.status-card,
-.status-card.compact {
-  border-color: var(--light-dark);
-  color: var(--dark-light);
-}
-
-.status-card__image {
-  background: var(--medium-dark);
-}
-
-.status-card__title {
-  color: var(--light);
-}
-
-a.status-card.compact:hover {
-  background-color: var(--light-dark);
+.reply-indicator__content a,
+.status__content a {
+  color: var(--accent);
 }
 
 .reply-indicator__content .status__content__spoiler-link,
 .status__content .status__content__spoiler-link {
   background: var(--light);
   color: var(--medium-dark);
+}
+
+.compose-form .compose-form__warning,
+.simple_form .recommended {
+  border-color: var(--accent);
+  background-color: rgb(63 143 245 / 20%);
+}
+
+.compose-form .compose-form__warning, .compose-form .compose-form__warning a {
+  color: var(--accent);
 }
 
 /* About */

--- a/public/custom.css
+++ b/public/custom.css
@@ -174,6 +174,10 @@
   background: var(--light-dark);
 }
 
+.theme-default .account__header__extra__links a {
+  color: var(--light);
+}
+
 .theme-default .column-subheading {
   color: var(--dark-light);
   background: var(--light-dark);
@@ -340,15 +344,14 @@
   background: var(--medium-dark);
 }
 
-.theme-default .admin-wrapper .content__heading__tabs a.selected,
-.admin-wrapper .content__heading__tabs a.selected:hover {
-  background: var(--accent);
-}
-
 .theme-default .fa-close::before,
 .theme-default .fa-remove::before,
 .theme-default .fa-times::before {
   color: var(--light);
+}
+
+.theme-default .admin-wrapper p a {
+  color: var(--medium-light) !important;
 }
 
 /***********************************
@@ -376,6 +379,7 @@
 .button:active,
 .button:focus,
 .button:hover,
+.button.logo-button:focus,
 .button.logo-button:hover {
   background-color: var(--light);
   color: var(--accent);
@@ -534,10 +538,6 @@
   color: var(--dark-light);
 }
 
-.account__header__extra__links a {
-  color: var(--light);
-}
-
 .account__header__bar {
   border-bottom: none;
 }
@@ -684,6 +684,7 @@ button.icon-button i.fa-retweet:hover {
 
 .compose-form .compose-form__warning,
 .simple_form .recommended {
+  color: var(--accent);
   border-color: var(--accent);
   background-color: rgb(63 143 245 / 20%);
 }
@@ -705,8 +706,13 @@ button.icon-button i.fa-retweet:hover {
   opacity: 0;
 }
 
-.admin-wrapper p a {
-  color: var(--light) !important;
+.admin-wrapper .content__heading__tabs a.selected,
+.admin-wrapper .content__heading__tabs a.selected:hover {
+  background: var(--accent);
+}
+
+ .admin-wrapper p a {
+  color: var(--dark) !important;
 }
 
 .admin-wrapper p a:hover {
@@ -764,6 +770,10 @@ button.icon-button i.fa-retweet:hover {
 .simple_form button:active,
 .simple_form button:focus {
   background-color: var(--light);
+  color: var(--accent);
+}
+
+.simple_form .hint a {
   color: var(--accent);
 }
 


### PR DESCRIPTION
This PR includes update to refine the existing custom css styles.

>  The existing styles were only available via the admin section as plain text pasted into an input. These styles are now in a separate file placed at: `/public/custom.css`. This enables adding custom css without having to go an copy and paste styles on the admin panel which is error prone, does not allow to keep version sor do any revision over changes. 

Updates to styles includes:

- Use custom accent color (blue) for primary call to action elements (buttons, inputs, etc)
- Update Settings section to use existing custom colors on dark mode
- Replace Mastodon logo for Mammoth icon on Settings section and mobile layout.

Timeline:
<img width="1534" alt="Screenshot 2023-03-16 at 0 17 56" src="https://user-images.githubusercontent.com/13956453/225531632-9d1accc0-e887-4eec-8122-cf2d6c5b638a.png">
<img width="1490" alt="Screenshot 2023-03-16 at 0 18 23" src="https://user-images.githubusercontent.com/13956453/225531634-56af0a68-c7ec-4827-b44f-f1ccc87bc4c5.png">

Settings:
<img width="1825" alt="Screenshot 2023-03-16 at 0 09 56" src="https://user-images.githubusercontent.com/13956453/225531651-a31915ef-33d9-44c6-ad31-302e3e0c8cfe.png">
<img width="1825" alt="Screenshot 2023-03-16 at 0 09 33" src="https://user-images.githubusercontent.com/13956453/225531711-d7207e6e-193b-42c2-9664-94529aaf4d51.png">


Profile: 
<img width="1825" alt="Screenshot 2023-03-16 at 0 10 35" src="https://user-images.githubusercontent.com/13956453/225531227-36aa137b-9f10-4306-8105-4fd5db57a69b.png">
<img width="1825" alt="Screenshot 2023-03-16 at 0 10 45" src="https://user-images.githubusercontent.com/13956453/225531152-9957ba8f-adff-49e0-829f-87965de99d09.png">

Mobile: 
<img width="612" alt="Screenshot 2023-03-16 at 0 07 41" src="https://user-images.githubusercontent.com/13956453/225531275-d4a039a0-4c19-4093-a3ae-8909004b0586.png">

