### PR TITLE
Fix: custom styles on search input and results

### DIFF
--- a/public/custom.css
+++ b/public/custom.css
@@ -165,6 +165,10 @@
   background: var(--light-dark);
 }
 
+.theme-default .columns-area {
+  background: var(--medium-dark);
+}
+
 .theme-default .navigation-bar__profile a {
   color: var(--light);
 }
@@ -180,8 +184,6 @@
 .theme-default .getting-started__wrapper {
   background: var(--medium-dark);
 }
-
-
 
 .theme-default .account__header__bar .avatar .account__avatar {
   background: var(--medium-dark);

--- a/public/custom.css
+++ b/public/custom.css
@@ -64,7 +64,29 @@
 
 .theme-default .search__input {
   background: var(--light-dark);
-  color: var(--medium-dark);
+  color: var(--light);
+}
+
+.theme-default .search-results__info {
+  color: var(--dark-light);
+}
+
+.theme-default .search-results__header {
+  background: var(--light-dark);
+  color: var(--light);
+}
+
+.theme-default .search-results__section h5 {
+  background: var(--medium-dark);
+  color: var(--medium-light);
+}
+
+.theme-default .drawer__inner {
+  background: var(--medium-dark);
+}
+
+.theme-default .drawer__inner.darker {
+  background: var(--light-dark);
 }
 
 .theme-default .column-header,
@@ -147,9 +169,19 @@
   color: var(--light);
 }
 
+.theme-default .trends__item__name a {
+  color: var(--light);
+}
+
+.theme-default .trends__item__name {
+  color: var(--dark-light);
+}
+
 .theme-default .getting-started__wrapper {
   background: var(--medium-dark);
 }
+
+
 
 .theme-default .account__header__bar .avatar .account__avatar {
   background: var(--medium-dark);
@@ -297,6 +329,10 @@
 
 .theme-default .detailed-status__action-bar {
   background-color: var(--medium-dark);
+}
+
+.theme-default .status__relative-time {
+  color: var(--medium-light);
 }
 
 /* Posts */
@@ -475,10 +511,6 @@
   border-color: var(--accent);
 }
 
-.search__input:focus {
-  background: var(--light);
-}
-
 .search__input::placeholder {
   color: var(--dark-light);
 }
@@ -490,14 +522,6 @@
 .getting-started__trends h4 {
   color: var(--light);
   border-bottom: var(--light-dark);
-}
-
-.trends__item__name a {
-  color: var(--light);
-}
-
-.trends__item__name {
-  color: var(--dark-light);
 }
 
 .getting-started__trends .trends__item__current {
@@ -589,10 +613,6 @@
 .status__display-name,
 .display-name__account {
   color: var(--dark-light);
-}
-
-.status__relative-time {
-  color: var(--medium-light);
 }
 
 .icon-button {


### PR DESCRIPTION
This PR includes styles fixes for the search input and results show on the side navigation.

Search column on the dark (default), high contrast and light mode. 
<img width="963" alt="image" src="https://user-images.githubusercontent.com/13956453/228421175-cbfc0282-a3a0-4e7c-9e02-03b0cb032537.png">

