### PR TITLE
MAM-1715-server-recommended-follow-v2-only-checking-username

### DIFF
--- a/app/controllers/api/v2/follow_recommendations_graph_controller.rb
+++ b/app/controllers/api/v2/follow_recommendations_graph_controller.rb
@@ -18,8 +18,13 @@ class Api::V2::FollowRecommendationsGraphController < Api::BaseController
 
   private
 
+  # Parse acct parameter
+  # return account if local user
+  # return 404 if not a local user
   def set_account
-    username, _domain = username_and_domain(params[:acct])
+    username, domain = username_and_domain(params[:acct])
+    return not_found unless TagManager.instance.local_domain?(domain)
+
     @account = Account.find_local(username)
   end
 


### PR DESCRIPTION
guard accounts not on local instance

For the current iteration, we are going to reply to **NON** Moth.social users with a 404. This updates the check for username **AND** domain. 
So if you're not on moth.social we send a 404 before looking up your account with find_local

## Try it
This will return error:
https://staging.moth.social/api/v2/follow_recommendations/?acct=jtomchak@mas.to
https://staging.moth.social/api/v2/follow_recommendations/?acct=jtomchak@moth.social

This will work:
https://staging.moth.social/api/v2/follow_recommendations/?acct=jtomchak@staging.moth.social