### PR TITLE
MAM-2310-add-parameter-to-to-v3-to-indicate-beta-group

### DIFF
--- a/app/controllers/api/v1/lists/accounts_controller.rb
+++ b/app/controllers/api/v1/lists/accounts_controller.rb
@@ -43,7 +43,6 @@ class Api::V1::Lists::AccountsController < Api::BaseController
         # Run the scheduler to populate the account's timeline
         handle = account.local? ? account.local_username_and_domain : account.acct
         PushFollowSuggestedWorker.perform_async(handle)
-        Scheduler::PersonalizedForYouStatusesScheduler.new.perform
       end
     end
   end

--- a/app/controllers/api/v3/timelines/for_you_controller.rb
+++ b/app/controllers/api/v3/timelines/for_you_controller.rb
@@ -6,7 +6,7 @@ class Api::V3::Timelines::ForYouController < Api::BaseController
   after_action :insert_pagination_headers, only: [:show], unless: -> { @statuses.empty? }
 
   def index
-    type = validate_owner_account ? 'Personal' : 'Public'
+    type = validate_owner_account ? 'personal' : 'public'
     render json: { type: type }
   end
 

--- a/app/controllers/api/v3/timelines/for_you_controller.rb
+++ b/app/controllers/api/v3/timelines/for_you_controller.rb
@@ -38,10 +38,9 @@ class Api::V3::Timelines::ForYouController < Api::BaseController
   end
 
   # Check for account on the peronalized list
-  # AND that account personalized feed has been populated
+  # AND that account personalized feed is NOT empty.
   def for_you_feed_type
-    on_personalized_list = validate_owner_account
-    if on_personalized_list && cached_personalized_statuses.empty?
+    if validate_owner_account && !cached_personalized_statuses.empty?
       'personal'
     else
       'public'

--- a/app/controllers/api/v3/timelines/for_you_controller.rb
+++ b/app/controllers/api/v3/timelines/for_you_controller.rb
@@ -3,7 +3,12 @@
 class Api::V3::Timelines::ForYouController < Api::BaseController
   before_action :set_for_you_default
 
-  after_action :insert_pagination_headers, unless: -> { @statuses.empty? }
+  after_action :insert_pagination_headers, only: [:show], unless: -> { @statuses.empty? }
+
+  def index
+    type = validate_owner_account ? 'Personal' : 'Public'
+    render json: { type: type }
+  end
 
   def show
     @statuses = set_for_you_feed

--- a/app/controllers/api/v3/timelines/for_you_controller.rb
+++ b/app/controllers/api/v3/timelines/for_you_controller.rb
@@ -32,7 +32,7 @@ class Api::V3::Timelines::ForYouController < Api::BaseController
       cached_personalized_statuses
     else
       # Getting the public feed
-      check_beta_status
+      enroll_beta
       cached_list_statuses
     end
   end
@@ -50,12 +50,12 @@ class Api::V3::Timelines::ForYouController < Api::BaseController
 
   # Only checking for beta parameter
   # After we've validated the acct is NOT on the beta list
-  # So if you're already on the beta list we're not going check
-  def check_beta_status
+  # So if you're already on the beta list we're not going add them
+  def enroll_beta
     if @is_beta_program
-      Rails.logger.info 'Beta Testflight>> TRUE'
-    else
-      Rails.logger.info 'Beta Testflight>> FALSE'
+      # Add to beta enrollment list
+      for_you = ForYouBeta.new
+      for_you.add_to_enrollment(acct_param)
     end
   end
 

--- a/app/lib/for_you_beta.rb
+++ b/app/lib/for_you_beta.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class ForYouBeta
+  include Redisable
+
+  def add_to_enrollment(handle)
+    key = key()
+    redis.sadd(key, handle)
+  end
+
+  def enrollment_list
+    key = key()
+    redis.smembers(key)
+  end
+
+  private
+
+  def key
+    'beta_enrollment:v1:accounts'
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -716,7 +716,9 @@ Rails.application.routes.draw do
     # V3
     namespace :v3 do
       namespace :timelines do
-        resource :for_you, only: :show, controller: :for_you
+        resource :for_you, only: [:show], controller: 'for_you' do
+          get '/me',      to: 'for_you#index'
+        end   
       end
     end
 


### PR DESCRIPTION
Adds the following

- [x] optional beta parameter for you
- [x] `/for_you/me` that will(for now) simply return the feed type 'Public' or 'Personal
- [x] passing `beta=true` will add the users mastodon handle to an array to be added to the Personalization list