### PR TITLE
MAM-2343-bump-metrics-updating-from-5-minutes-to-60-minutes

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -63,7 +63,7 @@
     class: Scheduler::SuspendedUserCleanupScheduler
   status_stat_update_scheduler:
     queue: scheduler
-    interval: '10m'
+    interval: '1h'
     class: Scheduler::StatusStatUpdateScheduler
   for_you_statuses_scheduler:
     queue: scheduler


### PR DESCRIPTION
This gives us some head room for rate limiting in the short term