### PR TITLE
MAM-2533-return-404-when-channel-by-id-is-not-found

### DIFF
--- a/app/controllers/api/v3/channels_controller.rb
+++ b/app/controllers/api/v3/channels_controller.rb
@@ -9,9 +9,15 @@ class Api::V3::ChannelsController < Api::BaseController
 
   def show
     @mammoth = Mammoth::Channels.new
-    @channel = @mammoth.find(channel_id_param)
-    render json: @channel
+    channel = @mammoth.find(channel_id_param)
+    render json: channel
   end
+
+  rescue_from Mammoth::Channels::NotFound do |e|
+    render json: { error: e.to_s }, status: 404
+  end
+
+  private
 
   def channel_id_param
     params.require(:id)

--- a/app/lib/mammoth/channels.rb
+++ b/app/lib/mammoth/channels.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 module Mammoth
   class Channels
+    class NotFound < StandardError; end
+
     ACCOUNT_RELAY_AUTH = "Bearer #{ENV.fetch('ACCOUNT_RELAY_KEY')}"
     ACCOUNT_RELAY_HOST = 'acctrelay.moth.social'
 
@@ -22,6 +24,8 @@ module Mammoth
         response = HTTP.headers({ Authorization: ACCOUNT_RELAY_AUTH, 'Content-Type': 'application/json' }).get(
           "https://#{ACCOUNT_RELAY_HOST}/api/v1/channels/#{id}"
         )
+        raise NotFound, 'channel not found' unless response.code == 200
+
         JSON.parse(response.body, symbolize_names: true)
       end
     end


### PR DESCRIPTION
* ensure correct errors when returning channel details