### PR TITLE
MAM-2544-remove-all-conditions-based-on-mothsocial-beta-list

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -8,7 +8,6 @@ class Api::BaseController < ApplicationController
   DEFAULT_STATUSES_LIST_LIMIT = 40
   FOR_YOU_OWNER_ACCOUNT = ENV['FOR_YOU_OWNER_ACCOUNT'] || 'admin'
   LIST_TITLE = 'For You'
-  BETA_FOR_YOU_LIST = 'Beta ForYou Personalized'
 
   include RateLimitHeaders
   include AccessTokenTrackingConcern

--- a/app/controllers/api/v1/lists/accounts_controller.rb
+++ b/app/controllers/api/v1/lists/accounts_controller.rb
@@ -21,8 +21,6 @@ class Api::V1::Lists::AccountsController < Api::BaseController
       end
     end
 
-    # Trigger after add accounts transaction
-    for_you_follow_suggestions
     render_empty
   end
 
@@ -32,20 +30,6 @@ class Api::V1::Lists::AccountsController < Api::BaseController
   end
 
   private
-
-  # For Mammoth Beta For You List ONLY
-  # Added accounts execute follow recommendation service then pushed to AccountRelay
-  def for_you_follow_suggestions
-    if current_account.username == FOR_YOU_OWNER_ACCOUNT && @list.title == BETA_FOR_YOU_LIST
-      list_accounts.each do |account|
-        # handle is full account (user@domain.com, jesse@moth.social)
-        # Push Suggested followers for account to AccountRelay Server
-        # Run the scheduler to populate the account's timeline
-        handle = account.local? ? account.local_username_and_domain : account.acct
-        PushFollowSuggestedWorker.perform_async(handle)
-      end
-    end
-  end
 
   def set_list
     @list = List.where(account: current_account).find(params[:list_id])

--- a/app/controllers/api/v3/timelines/for_you_controller.rb
+++ b/app/controllers/api/v3/timelines/for_you_controller.rb
@@ -32,13 +32,12 @@ class Api::V3::Timelines::ForYouController < Api::BaseController
 
   def set_for_you_default
     @default_owner_account = Account.local.where(username: FOR_YOU_OWNER_ACCOUNT).first!
-    @beta_for_you_list = List.where(account: @default_owner_account, title: BETA_FOR_YOU_LIST).first!
     @account = account_from_acct
     @is_beta_program = beta_param
   end
 
   def set_for_you_feed
-    should_personalize = validate_owner_account
+    should_personalize = validate_mammoth_account
     if should_personalize
       # Getting personalized
       fufill_personalized_statuses
@@ -49,25 +48,14 @@ class Api::V3::Timelines::ForYouController < Api::BaseController
     end
   end
 
-  # Check for account on the peronalized list
-  # AND that account personalized feed is NOT empty.
-  def for_you_feed_type
-    if validate_owner_account && !cached_personalized_statuses.empty?
-      'personal'
-    else
-      'public'
-    end
-  end
-
   # Check account_from_acct finds an account
   # Check the For You Beta Personal List
   # @return [Boolean]
-  def validate_owner_account
+  def validate_mammoth_account
     if @account.nil?
       return false
     end
-    @owner_account = @beta_for_you_list.accounts.without_suspended.includes(:account_stat).where(id: @account.id).first
-    !@owner_account.nil?
+    PersonalForYou.new.mammoth_user?(acct_param)
   end
 
   # Only checking for beta parameter

--- a/app/lib/personal_for_you.rb
+++ b/app/lib/personal_for_you.rb
@@ -3,30 +3,21 @@
 class PersonalForYou
   include Redisable
 
-  FOR_YOU_OWNER_ACCOUNT = ENV['FOR_YOU_OWNER_ACCOUNT'] || 'admin'
-  BETA_FOR_YOU_LIST = 'Beta ForYou Personalized'
   ACCOUNT_RELAY_AUTH = "Bearer #{ENV.fetch('ACCOUNT_RELAY_KEY')}"
   ACCOUNT_RELAY_HOST = 'acctrelay.moth.social'
 
-  def beta_list_accounts
-    default_owner_account = Account.local.where(username: FOR_YOU_OWNER_ACCOUNT).first!
-    beta_list = List.where(account: default_owner_account, title: BETA_FOR_YOU_LIST).first!
-    beta_list.accounts.without_suspended.includes(:account_stat)
-  end
-
   # Indirect Follows are the following of your followers
+  # Get full account handle <example@moth.social>
   # IE Friends of Friends
-  def statuses_for_indirect_follows(account)
-    # Get full account handle <example@moth.social>
-    account_handle = account.local? ? account.local_username_and_domain : account.acct
+  def statuses_for_indirect_follows(account_handle)
     cache_key = "follow_recommendations:#{account_handle}"
     fedi_account_handles = Rails.cache.fetch(cache_key)
     Rails.logger.debug { "INDIRECT FOLLOW RECOMMENDATIONS HANDLES\n #{fedi_account_handles}" }
     # Early return if no fedi account handles found
     return [] if fedi_account_handles.nil?
     # Parse handles into username & domain array for batch account query
-    username_query = Array.[]
-    domain_query = Array.[]
+    username_query = []
+    domain_query = []
     fedi_account_handles.each do |handle|
       h = handle.split('@')
       username_query.push(h[0])
@@ -48,16 +39,26 @@ class PersonalForYou
       "https://#{ACCOUNT_RELAY_HOST}/api/v1/foryou/users"
     )
     results = JSON.parse(response.body).map(&:symbolize_keys).pluck(:acct)
-    return results unless response.code != 200
+    results unless response.code != 200
   end
 
   # Get Mammoth user details
   # Includes any settings/preferences/configurations for feeds
   def user(acct)
-    response = HTTP.headers({ Authorization: ACCOUNT_RELAY_AUTH, 'Content-Type': 'application/json' }).get(
-      "https://#{ACCOUNT_RELAY_HOST}/api/v1/foryou/users/#{acct}"
-    )
-    JSON.parse(response.body, symbolize_names: true)
+    cache_key = "mammoth:user:#{acct}"
+    Rails.cache.fetch(cache_key, expires_in: 60.seconds) do
+      response = HTTP.headers({ Authorization: ACCOUNT_RELAY_AUTH, 'Content-Type': 'application/json' }).get(
+        "https://#{ACCOUNT_RELAY_HOST}/api/v1/foryou/users/#{acct}"
+      )
+      JSON.parse(response.body, symbolize_names: true)
+    end
+  end
+
+  # Defined as a 'local' user on AccountRelay
+  # A Mammoth user will have thier foryou settings type listed as 'personal'
+  # The default foryou settings type is 'public
+  def mammoth_user?(acct)
+    user(acct).dig(:for_you_settings, :type) == 'personal'
   end
 
   # PUT Mammoth user for you settings / preferences / status
@@ -75,15 +76,15 @@ class PersonalForYou
     )
     # Get Following
     results = JSON.parse(response.body)['following']
-    return results unless response.code != 200
+    results unless response.code != 200
   end
 
   def statuses_for_direct_follows(acct)
     following = user_following(acct)
     Rails.logger.debug { "FOLLOW RECOMMENDATIONS RETURN \n #{following}" }
     # Parse handles into username & domain array for batch account query
-    username_query = Array.[]
-    domain_query = Array.[]
+    username_query = []
+    domain_query = []
     following.each do |user|
       # Local accounts will have a domain of nil
       domain = user['domain'] == ENV['LOCAL_DOMAIN'] ? nil : user['domain']

--- a/app/workers/scheduler/status_stat_update_scheduler.rb
+++ b/app/workers/scheduler/status_stat_update_scheduler.rb
@@ -67,8 +67,8 @@ class Scheduler::StatusStatUpdateScheduler
   # Take the accounts from the beta list, get all the indirect follows
   def statuses_from_personalized_for_you
     personal_for_you = PersonalForYou.new
-    personal_for_you.beta_list_accounts
-                    .map { |account| personal_for_you.statuses_for_indirect_follows(account) }
+    personal_for_you.mammoth_users
+                    .map { |acct| personal_for_you.statuses_for_indirect_follows(acct) }
                     .flatten
   end
 

--- a/app/workers/scheduler/status_stat_update_scheduler.rb
+++ b/app/workers/scheduler/status_stat_update_scheduler.rb
@@ -63,10 +63,9 @@ class Scheduler::StatusStatUpdateScheduler
     end
   end
 
-  # Statuses from all the 'indirect follows' from all the accounts on the beta list
-  # Take the accounts from the beta list, get all the indirect follows
+  # Statuses from all the 'indirect follows' from all the accounts on from acctrelay that are Mammoth users
+  # Take the accounts from acctrelay that are Mammoth users, get all the indirect follows
   def statuses_from_personalized_for_you
-    personal_for_you = PersonalForYou.new
     mammoth_users
       .map { |acct| personal_for_you.statuses_for_indirect_follows(acct) }
       .flatten
@@ -75,9 +74,8 @@ class Scheduler::StatusStatUpdateScheduler
   # Statuses from all the 'direct follows' from all the accounts of Mammoth users
   # Take the users from Mammoth, get all the direct follows
   def statuses_from_direct_follows_for_you
-    personal_for_you = PersonalForYou.new
     mammoth_users
-      .map { |account| personal_for_you.statuses_for_direct_follows(account) }
+      .map { |acct| personal_for_you.statuses_for_direct_follows(acct) }
       .flatten
   end
 
@@ -100,6 +98,7 @@ class Scheduler::StatusStatUpdateScheduler
   end
 
   # Fetch acct of mammoth users from AcctRelay
+  # Returns array of acct strings ['jtomchak@moth.social, ...]
   def mammoth_users
     personal_for_you = PersonalForYou.new
     personal_for_you.acct_relay_users

--- a/app/workers/scheduler/status_stat_update_scheduler.rb
+++ b/app/workers/scheduler/status_stat_update_scheduler.rb
@@ -67,9 +67,9 @@ class Scheduler::StatusStatUpdateScheduler
   # Take the accounts from the beta list, get all the indirect follows
   def statuses_from_personalized_for_you
     personal_for_you = PersonalForYou.new
-    personal_for_you.mammoth_users
-                    .map { |acct| personal_for_you.statuses_for_indirect_follows(acct) }
-                    .flatten
+    mammoth_users
+      .map { |acct| personal_for_you.statuses_for_indirect_follows(acct) }
+      .flatten
   end
 
   # Statuses from all the 'direct follows' from all the accounts of Mammoth users


### PR DESCRIPTION
*rely on logic for `mammoth_user?` rather than the Moth.Social 'Beta List' that needed to be manually curated through the UI. 