### PR TITLE
 MAM-2555-proxy-api-for-addingremoving-channel-subscriptions-through-mothsocial

### DIFF
--- a/app/controllers/api/v3/channels_controller.rb
+++ b/app/controllers/api/v3/channels_controller.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class Api::V3::ChannelsController < Api::BaseController
+  rescue_from Mammoth::Channels::NotFound do |e|
+    render json: { error: e.to_s }, status: 404
+  end
+
   def index
     @mammoth = Mammoth::Channels.new
     channels_result = @mammoth.list
@@ -13,13 +17,25 @@ class Api::V3::ChannelsController < Api::BaseController
     render json: channel
   end
 
-  rescue_from Mammoth::Channels::NotFound do |e|
-    render json: { error: e.to_s }, status: 404
+  def subscribe
+    @mammoth = Mammoth::Channels.new
+    @user = @mammoth.subscribe(channel_id_param, acct_param)
+    render json: @user
+  end
+
+  def unsubscribe
+    @mammoth = Mammoth::Channels.new
+    @user = @mammoth.unsubscribe(channel_id_param, acct_param)
+    render json: @user
   end
 
   private
 
   def channel_id_param
     params.require(:id)
+  end
+
+  def acct_param
+    params.require(:acct)
   end
 end

--- a/app/controllers/api/v3/timelines/for_you_controller.rb
+++ b/app/controllers/api/v3/timelines/for_you_controller.rb
@@ -55,7 +55,7 @@ class Api::V3::Timelines::ForYouController < Api::BaseController
     if @account.nil?
       return false
     end
-    PersonalForYou.new.mammoth_user?(acct_param)
+    PersonalForYou.new.personalized_mammoth_user?(acct_param)
   end
 
   # Only checking for beta parameter

--- a/app/lib/mammoth/channels.rb
+++ b/app/lib/mammoth/channels.rb
@@ -18,6 +18,7 @@ module Mammoth
       end
     end
 
+    # GET channel by id and return all details
     def find(id)
       cache_key = "channels:list:#{id}"
       Rails.cache.fetch(cache_key, expires_in: 60.seconds) do
@@ -28,6 +29,28 @@ module Mammoth
 
         JSON.parse(response.body, symbolize_names: true)
       end
+    end
+
+    # Subscribe to Channel
+    def subscribe(id, acct)
+      response = HTTP.headers({ Authorization: ACCOUNT_RELAY_AUTH, 'Content-Type': 'application/json' }).post(
+        "https://#{ACCOUNT_RELAY_HOST}/api/v1/channels/#{id}/subscribe?acct=#{acct}"
+      )
+      raise NotFound, 'channel not found' unless response.code == 200
+      PersonalForYou.new.clear_user_cache(acct)
+
+      JSON.parse(response.body, symbolize_names: true)
+    end
+
+    # Unsubscribe to Channel
+    def unsubscribe(id, acct)
+      response = HTTP.headers({ Authorization: ACCOUNT_RELAY_AUTH, 'Content-Type': 'application/json' }).post(
+        "https://#{ACCOUNT_RELAY_HOST}/api/v1/channels/#{id}/unsubscribe?acct=#{acct}"
+      )
+      raise NotFound, 'channel not found' unless response.code == 200
+      PersonalForYou.new.clear_user_cache(acct)
+
+      JSON.parse(response.body, symbolize_names: true)
     end
   end
 end

--- a/app/lib/personal_for_you.rb
+++ b/app/lib/personal_for_you.rb
@@ -71,8 +71,13 @@ class PersonalForYou
     response = HTTP.headers({ Authorization: ACCOUNT_RELAY_AUTH, 'Content-Type': 'application/json' }).put(
       "https://#{ACCOUNT_RELAY_HOST}/api/v1/foryou/users/#{acct}", json: payload
     )
-    Rails.cache.delete(key(acct))
+    clear_user_cache(acct)
     JSON.parse(response.body)
+  end
+
+  # Cache bust local user
+  def clear_user_cache(acct)
+    Rails.cache.delete(key(acct))
   end
 
   # Get Mammoth user following

--- a/app/lib/personal_for_you.rb
+++ b/app/lib/personal_for_you.rb
@@ -38,7 +38,7 @@ class PersonalForYou
 
   # Get All registered users from AcctRely
   # `api/v1/foryou/users`
-  # That are local:true, meaning they are Mammoth Users
+  # That are  personalize:true, meaning they are Mammoth Users
   def acct_relay_users
     response = HTTP.headers({ Authorization: ACCOUNT_RELAY_AUTH, 'Content-Type': 'application/json' }).get(
       "https://#{ACCOUNT_RELAY_HOST}/api/v1/foryou/users"
@@ -49,19 +49,18 @@ class PersonalForYou
 
   # Get Mammoth user details
   # Includes any settings/preferences/configurations for feeds
+  # Not caching user. If it becomes an issue cache it at the source. AcctRelay
   def user(acct)
-    Rails.cache.fetch(key(acct), expires_in: 60.seconds) do
-      response = HTTP.headers({ Authorization: ACCOUNT_RELAY_AUTH, 'Content-Type': 'application/json' }).get(
-        "https://#{ACCOUNT_RELAY_HOST}/api/v1/foryou/users/#{acct}"
-      )
-      JSON.parse(response.body, symbolize_names: true)
-    end
+    response = HTTP.headers({ Authorization: ACCOUNT_RELAY_AUTH, 'Content-Type': 'application/json' }).get(
+      "https://#{ACCOUNT_RELAY_HOST}/api/v1/foryou/users/#{acct}"
+    )
+    JSON.parse(response.body, symbolize_names: true)
   end
 
-  # Defined as a 'local' user on AccountRelay
-  # A Mammoth user will have thier foryou settings type listed as 'personal'
+  # Defined as a 'personalize' user on AccountRelay
+  # A Mammoth user will have thier foryou settings type listed as 'personal' once it's generated
   # The default foryou settings type is 'public
-  def mammoth_user?(acct)
+  def personalized_mammoth_user?(acct)
     user(acct).dig(:for_you_settings, :type) == 'personal'
   end
 

--- a/app/workers/scheduler/for_you_mammoth_scheduler.rb
+++ b/app/workers/scheduler/for_you_mammoth_scheduler.rb
@@ -21,6 +21,7 @@ class Scheduler::ForYouMammothScheduler
   private
 
   # Fetch acct of mammoth users from AcctRelay
+  # These are users that are 'personalize'
   def mammoth_users
     personal_for_you = PersonalForYou.new
     Async do

--- a/app/workers/scheduler/status_stat_update_scheduler.rb
+++ b/app/workers/scheduler/status_stat_update_scheduler.rb
@@ -97,7 +97,7 @@ class Scheduler::StatusStatUpdateScheduler
     Account.local.where(username: FOR_YOU_OWNER_ACCOUNT)
   end
 
-  # Fetch acct of mammoth users from AcctRelay
+  # Fetch acct of mammoth users from AcctRelay that are 'personalize'
   # Returns array of acct strings ['jtomchak@moth.social, ...]
   def mammoth_users
     personal_for_you = PersonalForYou.new

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -715,7 +715,13 @@ Rails.application.routes.draw do
 
     # V3 Mammoth
     namespace :v3 do
-      resources :channels, only: [:index, :show]
+      resources :channels, only: [:index, :show] do 
+        member do
+          post :subscribe, constraints: { user_acct: %r{[^/]+} }
+          post :unsubscribe, constraints: { user_acct: %r{[^/]+} }
+        end
+      end 
+      
       namespace :timelines do
         resource :for_you, only: [:show], controller: 'for_you' do
           get '/me',      to: 'for_you#index'


### PR DESCRIPTION
* Adds subscribe and unsubscribe endpoints that a Mammoth user can use to add/remove channels from their personal channel selection
* Acknowledged that 'get mammoth users' has two parts. All Mammoth users, and those that have been 'personalized'