### PR TITLE
MAM-2558-channel-statuses-added-to-metrics-engine

### DIFF
--- a/app/lib/mammoth/channels.rb
+++ b/app/lib/mammoth/channels.rb
@@ -7,7 +7,7 @@ module Mammoth
     ACCOUNT_RELAY_HOST = 'acctrelay.moth.social'
 
     # GET all available channels as a list
-    # Channl includes id, title, description, owner
+    # Channel includes id, title, description, owner
     def list
       cache_key = 'channels:list'
       Rails.cache.fetch(cache_key, expires_in: 60.seconds) do
@@ -29,6 +29,15 @@ module Mammoth
 
         JSON.parse(response.body, symbolize_names: true)
       end
+    end
+
+    # GET all available channel accounts
+    # Account username, domain
+    def accounts
+      response = HTTP.headers({ Authorization: ACCOUNT_RELAY_AUTH, 'Content-Type': 'application/json' }).get(
+        "https://#{ACCOUNT_RELAY_HOST}/api/v1/channels/accounts"
+      )
+      JSON.parse(response.body, symbolize_names: true)
     end
 
     # Subscribe to Channel

--- a/app/workers/scheduler/channel_status_stat_update_scheduler.rb
+++ b/app/workers/scheduler/channel_status_stat_update_scheduler.rb
@@ -18,8 +18,8 @@ class Scheduler::ChannelStatusStatUpdateScheduler
 
   private
 
-  #   Iterate over all statuses
-  #  Pass id,uri to Update Worker
+  #  Iterate over all statuses
+  #  Pass {id,uri} to Update Worker
   def update_channel_account_status_stat!
     statuses_from_channel_accounts.each do |status|
       status_params = if status.reblog?
@@ -37,6 +37,7 @@ class Scheduler::ChannelStatusStatUpdateScheduler
   end
 
   # Get local account id's from channel accounts by username & domain
+  # This account id's are specific to Moth.Social. AcctRelay doesn't know about
   # Returns an array of account id's
   def accounts_list
     channel_accounts = mammoth_channel_accounts.wait
@@ -46,8 +47,9 @@ class Scheduler::ChannelStatusStatUpdateScheduler
     Account.where(username: usernames, domain: domains).pluck(:id)
   end
 
-  # Fetch acct of mammoth users from AcctRelay
-  # These are users that are 'personalize'
+  # Fetch all accounts of all channels from AcctRelay
+  # Bc we're updating statuses of accounts, the channel or channels they
+  # belong to is not needed
   def mammoth_channel_accounts
     channels = Mammoth::Channels.new
     Async do

--- a/app/workers/scheduler/channel_status_stat_update_scheduler.rb
+++ b/app/workers/scheduler/channel_status_stat_update_scheduler.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+class Scheduler::ChannelStatusStatUpdateScheduler
+  GO_BACK = 12 # number of hours back to fetch statuses
+
+  # Get Statuses for the last n hours from all accounts of all channels
+  # Iterate over and task a worker to fetch the status from original source
+  # Update the Status Stat for boosted & likes for that status in the stat table
+  include Sidekiq::Worker
+  include JsonLdHelper
+  include Async
+
+  sidekiq_options retry: 0
+
+  def perform
+    update_channel_account_status_stat!
+  end
+
+  private
+
+  #   Iterate over all statuses
+  #  Pass id,uri to Update Worker
+  def update_channel_account_status_stat!
+    statuses_from_channel_accounts.each do |status|
+      status_params = if status.reblog?
+                        { id: status.reblog.id, uri: status.reblog.uri }
+                      else
+                        { id: status.id, uri: status.uri }
+                      end
+      UpdateStatusStatWorker.perform_async(status_params)
+    end
+  end
+
+  def statuses_from_channel_accounts
+    Status.where(account_id: accounts_list,
+                 created_at: (GO_BACK.hours.ago)..Time.current)
+  end
+
+  # Get local account id's from channel accounts by username & domain
+  # Returns an array of account id's
+  def accounts_list
+    channel_accounts = mammoth_channel_accounts.wait
+    usernames = channel_accounts.pluck(:username)
+    domains = channel_accounts.map { |a| a[:domain] == ENV['LOCAL_DOMAIN'] ? nil : a[:domain] }
+
+    Account.where(username: usernames, domain: domains).pluck(:id)
+  end
+
+  # Fetch acct of mammoth users from AcctRelay
+  # These are users that are 'personalize'
+  def mammoth_channel_accounts
+    channels = Mammoth::Channels.new
+    Async do
+      channels.accounts
+    end
+  end
+end

--- a/app/workers/scheduler/status_stat_update_scheduler.rb
+++ b/app/workers/scheduler/status_stat_update_scheduler.rb
@@ -66,6 +66,7 @@ class Scheduler::StatusStatUpdateScheduler
   # Statuses from all the 'indirect follows' from all the accounts on from acctrelay that are Mammoth users
   # Take the accounts from acctrelay that are Mammoth users, get all the indirect follows
   def statuses_from_personalized_for_you
+    personal_for_you = PersonalForYou.new
     mammoth_users
       .map { |acct| personal_for_you.statuses_for_indirect_follows(acct) }
       .flatten
@@ -74,6 +75,7 @@ class Scheduler::StatusStatUpdateScheduler
   # Statuses from all the 'direct follows' from all the accounts of Mammoth users
   # Take the users from Mammoth, get all the direct follows
   def statuses_from_direct_follows_for_you
+    personal_for_you = PersonalForYou.new
     mammoth_users
       .map { |acct| personal_for_you.statuses_for_direct_follows(acct) }
       .flatten

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -65,6 +65,10 @@
     queue: scheduler
     interval: '30m'
     class: Scheduler::StatusStatUpdateScheduler
+  channel_status_stat_update_scheduler:
+    queue: scheduler
+    interval: '2m'
+    class: Scheduler::ChannelStatusStatUpdateScheduler
   for_you_statuses_scheduler:
     queue: scheduler
     interval: '5m'


### PR DESCRIPTION
* Adding Channels to metrics update engine. Added as a separate job from Mammoth Curated, follows, and following. Currently set aggressively at 2 minutes. Feels like we'll want this to be as accurate as possible and it's a finite about of accounts + statuses to check.