### PR TITLE
MAM-2598-generate-status-feeds-from-channels

### DIFF
--- a/app/lib/mammoth/channels.rb
+++ b/app/lib/mammoth/channels.rb
@@ -9,7 +9,7 @@ module Mammoth
     # GET all available channels as a list
     # Channel includes id, title, description, owner
     def list(include_accounts: false)
-      cache_key = 'channels:list'
+      cache_key = include_accounts ? 'channels:list:w_accounts' : 'channels:list'
       Rails.cache.fetch(cache_key, expires_in: 60.seconds) do
         response = HTTP.headers({ Authorization: ACCOUNT_RELAY_AUTH, 'Content-Type': 'application/json' }).get(
           "https://#{ACCOUNT_RELAY_HOST}/api/v1/channels?include_accounts=#{include_accounts}"

--- a/app/lib/mammoth/channels.rb
+++ b/app/lib/mammoth/channels.rb
@@ -8,11 +8,11 @@ module Mammoth
 
     # GET all available channels as a list
     # Channel includes id, title, description, owner
-    def list
+    def list(include_accounts: false)
       cache_key = 'channels:list'
       Rails.cache.fetch(cache_key, expires_in: 60.seconds) do
         response = HTTP.headers({ Authorization: ACCOUNT_RELAY_AUTH, 'Content-Type': 'application/json' }).get(
-          "https://#{ACCOUNT_RELAY_HOST}/api/v1/channels"
+          "https://#{ACCOUNT_RELAY_HOST}/api/v1/channels?include_accounts=#{include_accounts}"
         )
         JSON.parse(response.body, symbolize_names: true)
       end

--- a/app/models/mammoth_channel_feed.rb
+++ b/app/models/mammoth_channel_feed.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class MammothChannelFeed < Feed
+  def initialize(type, id)
+    @type = type.to_sym
+    super(@type, id)
+  end
+end

--- a/app/workers/channel_feed_worker.rb
+++ b/app/workers/channel_feed_worker.rb
@@ -17,7 +17,7 @@ class ChannelFeedWorker
     @options = options.symbolize_keys
 
     # perform_push_to_feed
-    Rails.logger.info { "CHANNELFEED_WORKER>>>>>>> #{@status_id.inspect}" }
+    Rails.logger.debug { "CHANNELFEED_WORKER>>>>>>> #{@status_id.inspect}" }
 
     add_to_feed!
   end

--- a/app/workers/channel_feed_worker.rb
+++ b/app/workers/channel_feed_worker.rb
@@ -18,7 +18,7 @@ class ChannelFeedWorker
     @options = options.symbolize_keys
 
     # perform_push_to_feed
-    Rails.logger.debug { "CHANNELFEED_WORKER>>>>>>> #{@status.inspect}" }
+    Rails.logger.info { "CHANNELFEED_WORKER>>>>>>> #{@status.inspect}" }
   rescue ActiveRecord::RecordNotFound
     # Status not found
     true

--- a/app/workers/channel_feed_worker.rb
+++ b/app/workers/channel_feed_worker.rb
@@ -37,19 +37,17 @@ class ChannelFeedWorker
     timeline_type = 'channel'
     timeline_key = FeedManager.instance.key(timeline_type, @channel_id)
 
-    redis.zadd(timeline_key, status.id, status.id)
+    redis.zadd(timeline_key, @status_id, @status_id)
 
     # Keep the list from growning infinitely
-    trim(timeline_key, account_id)
+    trim(timeline_key)
   end
 
   # Trim a feed to maximum size by removing older items
   # @param [Symbol] type
   # @param [Integer] timeline_id
   # @return [void]
-  def trim(type, timeline_id)
-    timeline_key = FeedManager.instance.key(type, timeline_id)
-
+  def trim(timeline_key)
     # Remove any items past the MAX_ITEMS'th entry in our feed
     redis.zremrangebyrank(timeline_key, 0, -(MAX_ITEMS + 1))
   end

--- a/app/workers/channel_feed_worker.rb
+++ b/app/workers/channel_feed_worker.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+# V1 of Mammoth Channel Feeds
+# Done by indiviual statuses and filtered. :foryou is the
+# Mammoth curated list
+class ChannelFeedWorker
+  include Redisable
+  include Sidekiq::Worker
+
+  sidekiq_options queue: 'pull', retry: 0
+
+  MAX_ITEMS = 1000
+  MINIMUM_ENGAGMENT_ACTIONS = 2
+
+  def perform(status_id, id, options = {})
+    @status = Status.find(status_id)
+    @channel_id = id
+    @options = options.symbolize_keys
+
+    # perform_push_to_feed
+    Rails.logger.debug { "CHANNELFEED_WORKER>>>>>>> #{@status.inspect}" }
+  rescue ActiveRecord::RecordNotFound
+    # Status not found
+    true
+  end
+
+  private
+
+  def perform_push_to_feed
+    case @type
+    when :personal
+      add_to_personal_feed(@type, @account_id, @status)
+
+    when :foryou
+      if filter_from_feed?(@status)
+        add_to_feed(@type, @list_id, @status)
+      end
+    end
+  end
+
+  # Check if status should not be added to the list feed
+  # Combine engagment actions. Greater than the min engagement set.
+  # Check status for reblog content or assign original content
+  # Reject statues with a reply_to or poll_id
+  # @param [Status] status
+  # @param [List] list
+  # @return [Boolean]
+  def filter_from_feed?(wrapped_status)
+    status = wrapped_status.reblog? ? wrapped_status.reblog : wrapped_status
+    status_counts = status.reblogs_count + status.replies_count + status.favourites_count
+
+    status_counts >= MINIMUM_ENGAGMENT_ACTIONS && status.in_reply_to_id.nil? && status.poll_id.nil?
+  end
+
+  # MAMMOTH: Taken directly from FeedManager
+
+  # Adds a status to an account's feed, returning true if a status was
+  # added, and false if it was not added to the feed. Note that this is
+  # an internal helper: callers must call trim or push updates if
+  # either action is appropriate.
+  # @param [Symbol] timeline_type
+  # @param [Integer] account_id
+  # @param [Status] status
+  # @param [Boolean] aggregate_reblogs
+  # @return [Boolean]
+  def add_to_feed(timeline_type, account_id, status)
+    timeline_key = FeedManager.instance.key(timeline_type, account_id)
+
+    redis.zadd(timeline_key, status.id, status.id)
+
+    # Keep the list from growning infinitely
+    trim(timeline_key, account_id)
+  end
+
+  # Adds to Account's Personal For You Feed
+  def add_to_personal_feed(timeline_type, account_id, status)
+    timeline_key = FeedManager.instance.key(timeline_type, account_id)
+
+    redis.zadd(timeline_key, status.id, status.id)
+
+    # Keep the list from growning infinitely
+    trim(timeline_key, account_id)
+  end
+
+  # Trim a feed to maximum size by removing older items
+  # @param [Symbol] type
+  # @param [Integer] timeline_id
+  # @return [void]
+  def trim(type, timeline_id)
+    timeline_key = FeedManager.instance.key(type, timeline_id)
+
+    # Remove any items past the MAX_ITEMS'th entry in our feed
+    redis.zremrangebyrank(timeline_key, 0, -(MAX_ITEMS + 1))
+  end
+end

--- a/app/workers/scheduler/channel_mammoth_statuses_scheduler.rb
+++ b/app/workers/scheduler/channel_mammoth_statuses_scheduler.rb
@@ -25,14 +25,14 @@ class Scheduler::ChannelMammothStatusesScheduler
   def update_channel_feeds!
     @channels = channels_with_statuses
     @channels.each do |channel|
-      Rails.logger.debug { "CHANNEL::  #{channel} \n" }
+      Rails.logger.info { "CHANNEL::  #{channel} \n" }
       push_statuses(channel[:statuses], channel[:id])
     end
   end
 
   def push_statuses(statuses, channel_id)
     statuses.each do |status|
-      Rails.logger.debug { "STATUS::  #{status} \n" }
+      Rails.logger.info { "STATUS::  #{status} \n" }
       ChannelFeedWorker.perform_async(status['id'], channel_id)
     end
   end

--- a/app/workers/scheduler/channel_mammoth_statuses_scheduler.rb
+++ b/app/workers/scheduler/channel_mammoth_statuses_scheduler.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'http'
+require 'json'
+# V1 Channels updating statuses for unique channel feeds
+class Scheduler::ChannelMammothStatusesScheduler
+  GO_BACK = 2 # number of hours back to fetch statuses
+
+  # Get Statuses for the last n hours from all channels
+  # Iterate over and task a worker to fetch the status from original source
+  include Sidekiq::Worker
+  include JsonLdHelper
+  include Async
+
+  sidekiq_options retry: 0
+
+  def perform
+    update_channel_feeds!
+  end
+
+  private
+
+  # Get statuses for accounts of each channel
+  # FeedWorker w/ status_id & channel_id will 'process' status
+  def update_channel_feeds!
+    @channels = channels_with_statuses
+    @channels.each do |channel|
+      Rails.logger.debug { "CHANNEL::  #{channel} \n" }
+      push_statuses(channel[:statuses], channel[:id])
+    end
+  end
+
+  def push_statuses(statuses, _channel_id)
+    statuses.each do |status|
+      Rails.logger.debug { "STATUS::  #{status} \n" }
+      ChannelFeedWorker.perform_async(status['id'], channel_id)
+    end
+  end
+
+  # Get all channels
+  # Get accounts for each channel
+  # process: filter by engagment and add cache set with channel_id key
+  def channels_with_statuses
+    mammoth_channels.wait.each do |channel|
+      account_ids = account_ids(channel[:accounts])
+      channel[:statuses] = statuses_from_channel_accounts(account_ids)
+    end
+  end
+
+  def statuses_from_channel_accounts(account_ids)
+    Status.where(account_id: account_ids,
+                 created_at: (GO_BACK.hours.ago)..Time.current)
+  end
+
+  # Returns an array of account id's
+  def account_ids(accounts)
+    usernames = accounts.pluck(:username)
+    domains = accounts.map { |a| a[:domain] == ENV['LOCAL_DOMAIN'] ? nil : a[:domain] }
+
+    Account.where(username: usernames, domain: domains).pluck(:id)
+  end
+
+  # Fetch all accounts of all channels from AcctRelay
+  # Bc we're getting statuses of particular channel accounts,
+  # the channel or channels the accounts need to be associated to their channels
+  def mammoth_channels
+    channels = Mammoth::Channels.new
+    Async do
+      channels.list(include_accounts: true)
+    end
+  end
+end

--- a/app/workers/scheduler/channel_mammoth_statuses_scheduler.rb
+++ b/app/workers/scheduler/channel_mammoth_statuses_scheduler.rb
@@ -78,6 +78,6 @@ class Scheduler::ChannelMammothStatusesScheduler
     status = wrapped_status.reblog? ? wrapped_status.reblog : wrapped_status
 
     status_counts = status.reblogs_count + status.replies_count + status.favourites_count
-    status if status_counts >= engagment[user_engagment_setting] && status.in_reply_to_id.nil? && status.poll_id.nil?
+    status if status_counts >= engagment && status.in_reply_to_id.nil? && status.poll_id.nil?
   end
 end

--- a/app/workers/scheduler/channel_mammoth_statuses_scheduler.rb
+++ b/app/workers/scheduler/channel_mammoth_statuses_scheduler.rb
@@ -30,7 +30,7 @@ class Scheduler::ChannelMammothStatusesScheduler
     end
   end
 
-  def push_statuses(statuses, _channel_id)
+  def push_statuses(statuses, channel_id)
     statuses.each do |status|
       Rails.logger.debug { "STATUS::  #{status} \n" }
       ChannelFeedWorker.perform_async(status['id'], channel_id)

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -69,6 +69,10 @@
     queue: scheduler
     interval: '2m'
     class: Scheduler::ChannelStatusStatUpdateScheduler
+  channel_statuses_scheduler:
+    queue: scheduler
+    interval: '5m'
+    class: Scheduler::ChannelMammothStatusesScheduler
   for_you_statuses_scheduler:
     queue: scheduler
     interval: '5m'

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -75,7 +75,7 @@
     class: Scheduler::ChannelMammothStatusesScheduler
   for_you_statuses_scheduler:
     queue: scheduler
-    interval: '5m'
+    interval: '2m'
     class: Scheduler::ForYouStatusesScheduler
   mammoth_for_you_statuses_scheduler:
     queue: scheduler


### PR DESCRIPTION
* Create Channel Feeds based on channels and accounts of that channel
* What we end up with is a generated Channel Feed of status ids that meet the minimum engagement threshold. 
* Persisted by Channel ID

<img width="812" alt="Medis 2023-09-11 at 11 22 37@2x" src="https://github.com/TheBLVD/moth.social/assets/76360/b389b049-0d79-4444-b525-2bde51ecdd24">
