### PR TITLE
MAM-2599-api-endpoints-for-each-channel-feed-by-channel-id

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -5,7 +5,7 @@ class Api::BaseController < ApplicationController
   MAX_LIMIT = 500
   DEFAULT_ACCOUNTS_LIMIT = 40
   # Mammoth Constants
-  DEFAULT_STATUSES_LIST_LIMIT = 40
+  DEFAULT_STATUSES_LIST_LIMIT = 40 # used for lists and channels
   FOR_YOU_OWNER_ACCOUNT = ENV['FOR_YOU_OWNER_ACCOUNT'] || 'admin'
   LIST_TITLE = 'For You'
 

--- a/app/controllers/api/v3/timelines/channels_controller.rb
+++ b/app/controllers/api/v3/timelines/channels_controller.rb
@@ -9,7 +9,7 @@ class Api::V3::Timelines::ChannelsController < Api::BaseController
 
   def show
     @statuses = channel_statuses
-    Rails.logger.debug { "STATUSES>>>>> #{@statues}" }
+    Rails.logger.info { "STATUSES>>>>> #{@statues}" }
     render json: @statuses,
            each_serializer: REST::StatusSerializer
   end
@@ -19,7 +19,7 @@ class Api::V3::Timelines::ChannelsController < Api::BaseController
   def set_channel
     @mammoth = Mammoth::Channels.new
     @channel = @mammoth.find(channel_id_param)
-    Rails.logger.debug { "CHANNEL:::::: #{@channel}" }
+    Rails.logger.info { "CHANNEL:::::: #{@channel}" }
   end
 
   def cached_channel_statuses

--- a/app/controllers/api/v3/timelines/channels_controller.rb
+++ b/app/controllers/api/v3/timelines/channels_controller.rb
@@ -47,6 +47,10 @@ class Api::V3::Timelines::ChannelsController < Api::BaseController
     set_pagination_headers(next_path, prev_path)
   end
 
+  def insert_pagination_headers
+    set_pagination_headers(next_path, prev_path)
+  end
+
   def pagination_params(core_params)
     params.slice(:limit).permit(:limit).merge(core_params)
   end

--- a/app/controllers/api/v3/timelines/channels_controller.rb
+++ b/app/controllers/api/v3/timelines/channels_controller.rb
@@ -28,7 +28,7 @@ class Api::V3::Timelines::ChannelsController < Api::BaseController
   end
 
   def channel_statuses
-    channel_feed.get(120,
+    channel_feed.get(DEFAULT_STATUSES_LIST_LIMIT,
                      params[:max_id],
                      params[:since_id],
                      params[:min_id])

--- a/app/controllers/api/v3/timelines/channels_controller.rb
+++ b/app/controllers/api/v3/timelines/channels_controller.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+class Api::V3::Timelines::ChannelsController < Api::BaseController
+  before_action :set_channel
+
+  rescue_from Mammoth::Channels::NotFound do |e|
+    render json: { error: e.to_s }, status: 404
+  end
+
+  def show
+    @statuses = channel_statuses
+    Rails.logger.debug { "STATUSES>>>>> #{@statues}" }
+    render json: @statuses,
+           each_serializer: REST::StatusSerializer
+  end
+
+  private
+
+  def set_channel
+    @mammoth = Mammoth::Channels.new
+    @channel = @mammoth.find(channel_id_param)
+    Rails.logger.debug { "CHANNEL:::::: #{@channel}" }
+  end
+
+  def cached_channel_statuses
+    cache_collection(channel_statuses, Status)
+  end
+
+  def channel_statuses
+    channel_feed.get(limit_param(1000),
+                     params[:max_id],
+                     params[:since_id],
+                     params[:min_id])
+  end
+
+  def channel_feed
+    MammothChannelFeed.new(@channel)
+  end
+
+  def channel_id_param
+    params.require(:id)
+  end
+
+  # PAGINATION
+  def insert_pagination_headers
+    set_pagination_headers(next_path, prev_path)
+  end
+
+  def pagination_params(core_params)
+    params.slice(:limit).permit(:limit).merge(core_params)
+  end
+
+  def next_path
+    api_v2_timelines_for_you_url pagination_params(max_id: pagination_max_id)
+  end
+
+  def prev_path
+    api_v2_timelines_for_you_url pagination_params(min_id: pagination_since_id)
+  end
+
+  def pagination_max_id
+    @statuses.last.id
+  end
+
+  def pagination_since_id
+    @statuses.first.id
+  end
+end

--- a/app/controllers/api/v3/timelines/channels_controller.rb
+++ b/app/controllers/api/v3/timelines/channels_controller.rb
@@ -8,7 +8,7 @@ class Api::V3::Timelines::ChannelsController < Api::BaseController
   end
 
   def show
-    @statuses = channel_statuses
+    @statuses = cached_channel_statuses
     Rails.logger.info { "STATUSES>>>>> #{@statues}" }
     render json: @statuses,
            each_serializer: REST::StatusSerializer,
@@ -28,7 +28,7 @@ class Api::V3::Timelines::ChannelsController < Api::BaseController
   end
 
   def channel_statuses
-    channel_feed.get(limit_param(1000),
+    channel_feed.get(120,
                      params[:max_id],
                      params[:since_id],
                      params[:min_id])

--- a/app/controllers/api/v3/timelines/channels_controller.rb
+++ b/app/controllers/api/v3/timelines/channels_controller.rb
@@ -3,7 +3,7 @@
 class Api::V3::Timelines::ChannelsController < Api::BaseController
   before_action :set_channel
 
-  after_action :insert_pagination_headers, only: [:show], unless: -> { @statuses.empty? }
+  # after_action :insert_pagination_headers, only: [:show], unless: -> { @statuses.empty? }
 
   rescue_from Mammoth::Channels::NotFound do |e|
     render json: { error: e.to_s }, status: 404
@@ -43,31 +43,27 @@ class Api::V3::Timelines::ChannelsController < Api::BaseController
   end
 
   # PAGINATION
-  def insert_pagination_headers
-    set_pagination_headers(next_path, prev_path)
-  end
+  # def insert_pagination_headers
+  #   set_pagination_headers(next_path, prev_path)
+  # end
 
-  def insert_pagination_headers
-    set_pagination_headers(next_path, prev_path)
-  end
+  # def pagination_params(core_params)
+  #   params.slice(:limit).permit(:limit).merge(core_params)
+  # end
 
-  def pagination_params(core_params)
-    params.slice(:limit).permit(:limit).merge(core_params)
-  end
+  # def next_path
+  #   api_v3_timelines_channels_url pagination_params(max_id: pagination_max_id)
+  # end
 
-  def next_path
-    api_v3_timelines_channels_url pagination_params(max_id: pagination_max_id)
-  end
+  # def prev_path
+  #   api_v3_timelines_channels_url pagination_params(min_id: pagination_since_id)
+  # end
 
-  def prev_path
-    api_v3_timelines_channels_url pagination_params(min_id: pagination_since_id)
-  end
+  # def pagination_max_id
+  #   @statuses.last.id
+  # end
 
-  def pagination_max_id
-    @statuses.last.id
-  end
-
-  def pagination_since_id
-    @statuses.first.id
-  end
+  # def pagination_since_id
+  #   @statuses.first.id
+  # end
 end

--- a/app/controllers/api/v3/timelines/channels_controller.rb
+++ b/app/controllers/api/v3/timelines/channels_controller.rb
@@ -23,7 +23,8 @@ class Api::V3::Timelines::ChannelsController < Api::BaseController
   end
 
   def cached_channel_statuses
-    cache_collection(channel_statuses, Status)
+    # cache_collection(channel_statuses, Status)
+    channel_statuses
   end
 
   def channel_statuses

--- a/app/controllers/api/v3/timelines/channels_controller.rb
+++ b/app/controllers/api/v3/timelines/channels_controller.rb
@@ -27,6 +27,7 @@ class Api::V3::Timelines::ChannelsController < Api::BaseController
     cache_collection channel_statuses, Status
   end
 
+  # LIST_LIMT set in Api::BaseController
   def channel_statuses
     channel_feed.get(DEFAULT_STATUSES_LIST_LIMIT,
                      params[:max_id],

--- a/app/controllers/api/v3/timelines/channels_controller.rb
+++ b/app/controllers/api/v3/timelines/channels_controller.rb
@@ -3,7 +3,7 @@
 class Api::V3::Timelines::ChannelsController < Api::BaseController
   before_action :set_channel
 
-  # after_action :insert_pagination_headers, only: [:show], unless: -> { @statuses.empty? }
+  after_action :insert_pagination_headers, only: [:show], unless: -> { @statuses.empty? }
 
   rescue_from Mammoth::Channels::NotFound do |e|
     render json: { error: e.to_s }, status: 404
@@ -43,27 +43,27 @@ class Api::V3::Timelines::ChannelsController < Api::BaseController
   end
 
   # PAGINATION
-  # def insert_pagination_headers
-  #   set_pagination_headers(next_path, prev_path)
-  # end
+  def insert_pagination_headers
+    set_pagination_headers(next_path, prev_path)
+  end
 
-  # def pagination_params(core_params)
-  #   params.slice(:limit).permit(:limit).merge(core_params)
-  # end
+  def pagination_params(core_params)
+    params.slice(:limit).permit(:limit).merge(core_params)
+  end
 
-  # def next_path
-  #   api_v3_timelines_channels_url pagination_params(max_id: pagination_max_id)
-  # end
+  def next_path
+    api_v3_timelines_channel_url pagination_params(max_id: pagination_max_id)
+  end
 
-  # def prev_path
-  #   api_v3_timelines_channels_url pagination_params(min_id: pagination_since_id)
-  # end
+  def prev_path
+    api_v3_timelines_channel_url pagination_params(min_id: pagination_since_id)
+  end
 
-  # def pagination_max_id
-  #   @statuses.last.id
-  # end
+  def pagination_max_id
+    @statuses.last.id
+  end
 
-  # def pagination_since_id
-  #   @statuses.first.id
-  # end
+  def pagination_since_id
+    @statuses.first.id
+  end
 end

--- a/app/controllers/api/v3/timelines/channels_controller.rb
+++ b/app/controllers/api/v3/timelines/channels_controller.rb
@@ -23,8 +23,7 @@ class Api::V3::Timelines::ChannelsController < Api::BaseController
   end
 
   def cached_channel_statuses
-    # cache_collection(channel_statuses, Status)
-    channel_statuses
+    cache_collection channel_statuses, Status
   end
 
   def channel_statuses

--- a/app/controllers/api/v3/timelines/channels_controller.rb
+++ b/app/controllers/api/v3/timelines/channels_controller.rb
@@ -11,7 +11,8 @@ class Api::V3::Timelines::ChannelsController < Api::BaseController
     @statuses = channel_statuses
     Rails.logger.info { "STATUSES>>>>> #{@statues}" }
     render json: @statuses,
-           each_serializer: REST::StatusSerializer
+           each_serializer: REST::StatusSerializer,
+           relationships: StatusRelationshipsPresenter.new(@statuses, current_user&.account_id)
   end
 
   private

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -30,7 +30,7 @@ class Feed
     Rails.logger.info { "STATUS IDS>>>>> #{unhydrated} \n" }
     statuses = Status.where(id: unhydrated).cache_ids
     Rails.logger.info { "STATUS >>>>> #{statuses.inspect}" }
-    statues
+    statuses
   end
 
   def key

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -27,8 +27,10 @@ class Feed
     else
       unhydrated = redis.zrangebyscore(key, "(#{min_id}", "(#{max_id}", limit: [0, limit], with_scores: true).map(&:first).map(&:to_i)
     end
-    Rails.logger.info { "STATUS IDS>>>>> #{unhydrated}" }
-    Status.where(id: unhydrated).cache_ids
+    Rails.logger.info { "STATUS IDS>>>>> #{unhydrated} \n" }
+    statuses = Status.where(id: unhydrated).cache_ids
+    Rails.logger.info { "STATUS >>>>> #{statuses.inspect}" }
+    statues
   end
 
   def key

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -27,10 +27,7 @@ class Feed
     else
       unhydrated = redis.zrangebyscore(key, "(#{min_id}", "(#{max_id}", limit: [0, limit], with_scores: true).map(&:first).map(&:to_i)
     end
-    Rails.logger.info { "STATUS IDS>>>>> #{unhydrated} \n" }
-    statuses = Status.where(id: unhydrated).cache_ids
-    Rails.logger.info { "STATUS >>>>> #{statuses.inspect}" }
-    statuses
+    Status.where(id: unhydrated).cache_ids
   end
 
   def key

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -27,7 +27,7 @@ class Feed
     else
       unhydrated = redis.zrangebyscore(key, "(#{min_id}", "(#{max_id}", limit: [0, limit], with_scores: true).map(&:first).map(&:to_i)
     end
-
+    Rails.logger.info { "STATUS IDS>>>>> #{unhydrated}" }
     Status.where(id: unhydrated).cache_ids
   end
 

--- a/app/models/mammoth_channel_feed.rb
+++ b/app/models/mammoth_channel_feed.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 class MammothChannelFeed < Feed
-  def initialize(type, id)
-    @type = type.to_sym
-    super(@type, id)
+  def initialize(channel)
+    super(:channel, channel[:id])
   end
 end

--- a/app/models/mammoth_channel_feed.rb
+++ b/app/models/mammoth_channel_feed.rb
@@ -3,5 +3,37 @@
 class MammothChannelFeed < Feed
   def initialize(channel)
     super(:channel, channel[:id])
+    @type = :channel
+    @id   = channel[:id]
+  end
+
+
+  def get(limit, max_id = nil, since_id = nil, min_id = nil)
+    limit    = limit.to_i
+    max_id   = max_id.to_i if max_id.present?
+    since_id = since_id.to_i if since_id.present?
+    min_id   = min_id.to_i if min_id.present?
+
+    from_redis(limit, max_id, since_id, min_id)
+  end
+
+  protected
+
+  def from_redis(limit, max_id, since_id, min_id)
+    max_id = '+inf' if max_id.blank?
+    if min_id.blank?
+      since_id   = '-inf' if since_id.blank?
+      unhydrated = redis.zrevrangebyscore(key, "(#{max_id}", "(#{since_id}", limit: [0, limit], with_scores: true).map(&:first).map(&:to_i)
+    else
+      unhydrated = redis.zrangebyscore(key, "(#{min_id}", "(#{max_id}", limit: [0, limit], with_scores: true).map(&:first).map(&:to_i)
+    end
+    Rails.logger.info { "STATUS IDS>>>>> #{unhydrated} \n" }
+    statuses = Status.where(id: unhydrated).cache_ids
+    Rails.logger.info { "STATUS >>>>> #{statuses.inspect}" }
+    statuses
+  end
+
+  def key
+    FeedManager.instance.key(@type, @id)
   end
 end

--- a/app/models/mammoth_channel_feed.rb
+++ b/app/models/mammoth_channel_feed.rb
@@ -3,37 +3,5 @@
 class MammothChannelFeed < Feed
   def initialize(channel)
     super(:channel, channel[:id])
-    @type = :channel
-    @id   = channel[:id]
-  end
-
-
-  def get(limit, max_id = nil, since_id = nil, min_id = nil)
-    limit    = limit.to_i
-    max_id   = max_id.to_i if max_id.present?
-    since_id = since_id.to_i if since_id.present?
-    min_id   = min_id.to_i if min_id.present?
-
-    from_redis(limit, max_id, since_id, min_id)
-  end
-
-  protected
-
-  def from_redis(limit, max_id, since_id, min_id)
-    max_id = '+inf' if max_id.blank?
-    if min_id.blank?
-      since_id   = '-inf' if since_id.blank?
-      unhydrated = redis.zrevrangebyscore(key, "(#{max_id}", "(#{since_id}", limit: [0, limit], with_scores: true).map(&:first).map(&:to_i)
-    else
-      unhydrated = redis.zrangebyscore(key, "(#{min_id}", "(#{max_id}", limit: [0, limit], with_scores: true).map(&:first).map(&:to_i)
-    end
-    Rails.logger.info { "STATUS IDS>>>>> #{unhydrated} \n" }
-    statuses = Status.where(id: unhydrated).cache_ids
-    Rails.logger.info { "STATUS >>>>> #{statuses.inspect}" }
-    statuses
-  end
-
-  def key
-    FeedManager.instance.key(@type, @id)
   end
 end

--- a/app/workers/channel_feed_worker.rb
+++ b/app/workers/channel_feed_worker.rb
@@ -34,8 +34,7 @@ class ChannelFeedWorker
   # @param [Status] status_id
   # @return [Boolean]
   def add_to_feed!
-    timeline_type = 'channel'
-    timeline_key = FeedManager.instance.key(timeline_type, @channel_id)
+    timeline_key = FeedManager.instance.key(:channel, @channel_id)
 
     redis.zadd(timeline_key, @status_id, @status_id)
 

--- a/app/workers/scheduler/channel_mammoth_statuses_scheduler.rb
+++ b/app/workers/scheduler/channel_mammoth_statuses_scheduler.rb
@@ -5,7 +5,7 @@ require 'json'
 # V1 Channels updating statuses for unique channel feeds
 class Scheduler::ChannelMammothStatusesScheduler
   GO_BACK = 2 # number of hours back to fetch statuses
-  MINIMUM_ENGAGMENT_ACTIONS = 2
+  MINIMUM_ENGAGMENT_ACTIONS = 0
 
   # Get Statuses for the last n hours from all channels
   # Iterate over and task a worker to fetch the status from original source

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -723,7 +723,7 @@ Rails.application.routes.draw do
       end 
       
       namespace :timelines do
-        get 'channels/:id', to: 'channels#show'
+        resources :channels, only: :show, controller: :channels
         resource :for_you, only: [:show], controller: 'for_you' do
           get '/me',      to: 'for_you#index'
           put '/me',      to: 'for_you#update'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -723,6 +723,7 @@ Rails.application.routes.draw do
       end 
       
       namespace :timelines do
+        get 'channels/:id', to: 'channels#show'
         resource :for_you, only: [:show], controller: 'for_you' do
           get '/me',      to: 'for_you#index'
           put '/me',      to: 'for_you#update'


### PR DESCRIPTION
* Return Channel Statuses by channel id
* Return with pagination, like a list
* Current implementation is 0 minimum engagement filter
* Running every 2 minutes checking for new content

This will return statuses for Photography:
`https://staging.moth.social/api/v3/timelines/channels/80466334-64fa-42e1-8d61-fa3834abb190`

page two
`https://staging.moth.social/api/v3/timelines/channels/80466334-64fa-42e1-8d61-fa3834abb190?max_id=111053606868616245`
```json
[
    {
        "id": "111058670043051700",
        "created_at": "2023-09-13T16:00:19.000Z",
        "in_reply_to_id": null,
        "in_reply_to_account_id": null,
        "sensitive": false,
        "spoiler_text": "",
        "visibility": "public",
        "language": "en",
        "uri": "https://mastodon.art/users/jonwoodhamsartandphoto/statuses/111058670016733177",
        "url": "https://mastodon.art/@jonwoodhamsartandphoto/111058670016733177",
        "replies_count": 1,
        "reblogs_count": 2,
        "favourites_count": 2,
        "edited_at": null,
        "content": "<p>I love working with whorls and spirals--the tunnel effect in this piece is something I've explored in quite a lot of my work. This piece, No. 628, is a recent work from me that taps into that impulse, which grew out of some health issues some years ago. Find it here: <a href=\"https://jon-woodhams.pixels.com/featured/no-628-jon-woodhams.html\" rel=\"nofollow noopener noreferrer\" target=\"_blank\"><span class=\"invisible\">https://</span><span class=\"ellipsis\">jon-woodhams.pixels.com/
```
