### PR TITLE
MAM-2600-users-foryou-feed-incorporates-their-subscribed-channels

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -11,6 +11,7 @@ class Api::BaseController < ApplicationController
 
   include RateLimitHeaders
   include AccessTokenTrackingConcern
+  include Async
 
   skip_before_action :store_current_location
   skip_before_action :require_functional!, unless: :whitelist_mode?

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -11,7 +11,6 @@ class Api::BaseController < ApplicationController
 
   include RateLimitHeaders
   include AccessTokenTrackingConcern
-  include Async
 
   skip_before_action :store_current_location
   skip_before_action :require_functional!, unless: :whitelist_mode?

--- a/app/lib/mammoth/channels.rb
+++ b/app/lib/mammoth/channels.rb
@@ -18,9 +18,9 @@ module Mammoth
     end
 
     def select_channels_with_statuses(channels)
-      channels.each do |channel|
+      channels.flat_map do |channel|
         account_ids = account_ids(channel[:accounts])
-        channel[:statuses] = statuses_from_channel_accounts(account_ids)
+        statuses_from_channel_accounts(account_ids)
       end
     end
 

--- a/app/lib/mammoth/channels.rb
+++ b/app/lib/mammoth/channels.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 module Mammoth
   class Channels
-    include Async
-    
     class NotFound < StandardError; end
 
     GO_BACK = 2 # number of hours back to fetch statuses
@@ -13,7 +11,7 @@ module Mammoth
     # Get accounts for each channel
     # process: filter by engagment and add cache set with channel_id key
     def channels_with_statuses
-      mammoth_channels.wait.each do |channel|
+      list(include_accounts: true).each do |channel|
         account_ids = account_ids(channel[:accounts])
         channel[:statuses] = statuses_from_channel_accounts(account_ids)
       end
@@ -37,15 +35,6 @@ module Mammoth
       domains = accounts.map { |a| a[:domain] == ENV['LOCAL_DOMAIN'] ? nil : a[:domain] }
 
       Account.where(username: usernames, domain: domains).pluck(:id)
-    end
-
-    # Fetch all accounts of all channels from AcctRelay
-    # Bc we're getting statuses of particular channel accounts,
-    # the channel or channels the accounts need to be associated to their channels
-    def mammoth_channels
-      Async do
-        list(include_accounts: true)
-      end
     end
 
     # HTTP METHODS

--- a/app/lib/mammoth/channels.rb
+++ b/app/lib/mammoth/channels.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 module Mammoth
   class Channels
+    include Async
+    
     class NotFound < StandardError; end
 
     GO_BACK = 2 # number of hours back to fetch statuses

--- a/app/lib/mammoth/channels.rb
+++ b/app/lib/mammoth/channels.rb
@@ -3,7 +3,7 @@ module Mammoth
   class Channels
     class NotFound < StandardError; end
 
-    GO_BACK = 2 # number of hours back to fetch statuses
+    GO_BACK = 24 # number of hours back to fetch statuses
     ACCOUNT_RELAY_AUTH = "Bearer #{ENV.fetch('ACCOUNT_RELAY_KEY')}"
     ACCOUNT_RELAY_HOST = 'acctrelay.moth.social'
 

--- a/app/lib/personal_for_you.rb
+++ b/app/lib/personal_for_you.rb
@@ -113,6 +113,7 @@ class PersonalForYou
   def statuses_for_subscribed_channels(user)
     channels = Mammoth::Channels.new
     subscribed_channels = subscribed_channels(user)
+
     channels.select_channels_with_statuses(subscribed_channels)
   end
 

--- a/app/lib/personal_for_you.rb
+++ b/app/lib/personal_for_you.rb
@@ -118,8 +118,8 @@ class PersonalForYou
   end
 
   # Only include channels from user subscribed
-  # Return 'mammoth channels' that has the full accounts array
-  # User's subscribed array only has channel summary
+  # Return channels with full account details array
+  # User's subscribed array from `/me` only has channel summary
   def subscribed_channels(user)
     channels = mammoth_channels
     subscribed_channels = user[:subscribed_channels]

--- a/app/lib/personal_for_you.rb
+++ b/app/lib/personal_for_you.rb
@@ -2,7 +2,6 @@
 
 class PersonalForYou
   include Redisable
-  include Async
 
   ACCOUNT_RELAY_AUTH = "Bearer #{ENV.fetch('ACCOUNT_RELAY_KEY')}"
   ACCOUNT_RELAY_HOST = 'acctrelay.moth.social'
@@ -121,10 +120,10 @@ class PersonalForYou
   # Return 'mammoth channels' that has the full accounts array
   # User's subscribed array only has channel summary
   def subscribed_channels(user)
-    channels = mammoth_channels.wait
+    channels = mammoth_channels
     subscribed_channels = user[:subscribed_channels]
 
-    subscribed_channels.wait.flat_map do |channel|
+    subscribed_channels.flat_map do |channel|
       channels.filter do |c|
         c[:id] == channel[:id]
       end
@@ -133,9 +132,7 @@ class PersonalForYou
 
   def mammoth_channels
     channels = Mammoth::Channels.new
-    Async do
-      channels.list(include_accounts: true)
-    end
+    channels.list(include_accounts: true)
   end
 
   # Remove personal timeline this will remove all entries in user's personal for you feed

--- a/app/workers/update_for_you_worker.rb
+++ b/app/workers/update_for_you_worker.rb
@@ -114,7 +114,7 @@ class UpdateForYouWorker
     when 'following'
       { 1 => 2, 2 => 4, 3 => 6 }
     when 'channel'
-      { 1 => 0, 2 => 1, 3 => 1 }
+      { 1 => 0, 2 => 1, 3 => 2 }
     when 'indirect', 'public'
       { 1 => 1, 2 => 2, 3 => 3 }
     end

--- a/app/workers/update_for_you_worker.rb
+++ b/app/workers/update_for_you_worker.rb
@@ -43,6 +43,8 @@ class UpdateForYouWorker
     push_indirect_following_status
     # Direct Follows
     push_following_status
+    # Channel Feed
+    push_channels_status
     # Public Feed
   end
 
@@ -84,6 +86,16 @@ class UpdateForYouWorker
              .each { |s| ForYouFeedWorker.perform_async(s['id'], @account.id, 'personal') }
   end
 
+  # Channels Subscribed too
+  def push_channels_status
+    user_setting = @user[:for_you_settings]
+    return if user_setting[:from_your_channels].zero?
+
+    @personal.statuses_for_subscribed_channels(@user)
+             .filter_map { |s| engagment_threshold(s, user_setting[:from_your_channels], 'channel') }
+             .each { |s| ForYouFeedWorker.perform_async(s['id'], @account.id, 'personal') }
+  end
+
   # Check status for User's level of engagment
   # Filter out polls and replys
   def engagment_threshold(wrapped_status, user_engagment_setting, type)
@@ -101,6 +113,8 @@ class UpdateForYouWorker
     case type
     when 'following'
       { 1 => 2, 2 => 4, 3 => 6 }
+    when 'channel'
+      { 1 => 0, 2 => 1, 3 => 1 }
     when 'indirect', 'public'
       { 1 => 1, 2 => 2, 3 => 3 }
     end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -71,11 +71,11 @@
     class: Scheduler::ChannelStatusStatUpdateScheduler
   channel_statuses_scheduler:
     queue: scheduler
-    interval: '5m'
+    interval: '2m'
     class: Scheduler::ChannelMammothStatusesScheduler
   for_you_statuses_scheduler:
     queue: scheduler
-    interval: '2m'
+    interval: '5m'
     class: Scheduler::ForYouStatusesScheduler
   mammoth_for_you_statuses_scheduler:
     queue: scheduler


### PR DESCRIPTION
* User's subscribed channels will be added to their ForYou feed
   * Note. There is an edge case where you subscribe to a channel, you won't immediately see it in your ForYou feed until it's updated server side. That happens every 5 minutes.

### Example of seeing #News Channel in my ForYou feed
![RocketSim_Screenshot_iPhone_14_Pro_2023-09-15_10 11 46](https://github.com/TheBLVD/moth.social/assets/76360/0ac2c32e-557a-4b4b-a9b3-62f0f6c40a64)
![RocketSim_Screenshot_iPhone_14_Pro_2023-09-15_10 11 31](https://github.com/TheBLVD/moth.social/assets/76360/5e1e8232-4ee3-481d-9af5-a74dc76a6bda)
