### PR TITLE
MAM-2709-stat-backoff-from-2m-10m

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -67,11 +67,11 @@
     class: Scheduler::StatusStatUpdateScheduler
   channel_status_stat_update_scheduler:
     queue: scheduler
-    interval: '2m'
+    interval: '10m'
     class: Scheduler::ChannelStatusStatUpdateScheduler
   channel_statuses_scheduler:
     queue: scheduler
-    interval: '2m'
+    interval: '10m'
     class: Scheduler::ChannelMammothStatusesScheduler
   for_you_statuses_scheduler:
     queue: scheduler

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -71,7 +71,7 @@
     class: Scheduler::ChannelStatusStatUpdateScheduler
   channel_statuses_scheduler:
     queue: scheduler
-    interval: '10m'
+    interval: '2m'
     class: Scheduler::ChannelMammothStatusesScheduler
   for_you_statuses_scheduler:
     queue: scheduler


### PR DESCRIPTION
Moving stat status collection job from 2m -> 10m. 