### PR TITLE
MAM-2692-authenticated-calls-from-mammoth-to-mothsocial 

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -82,3 +82,7 @@ FOR_YOU_OWNER_ACCOUNT=admin
 # Token Authorization Key for AccountRelay Server
 ACCOUNT_RELAY_KEY=xxxxxx
 
+
+# JWT Decode MAMMOTH AUTHENTICATION
+MAMMOTH_SECRET_KEY=xxxxxx
+

--- a/Gemfile
+++ b/Gemfile
@@ -167,3 +167,6 @@ gem 'bcrypt_pbkdf', '>= 1.0', '< 2.0'
 # Async
 gem 'async', '~> 1.31'
 gem 'async-http'
+
+# Use Json Web Token (JWT) for token based authentication Mammoth
+gem 'jwt'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -871,6 +871,7 @@ DEPENDENCIES
   json-ld
   json-ld-preloaded (~> 3.2)
   json-schema (~> 3.0)
+  jwt
   kaminari (~> 1.2)
   kt-paperclip (~> 7.1)
   letter_opener (~> 1.8)

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -145,6 +145,20 @@ class Api::BaseController < ApplicationController
     end
   end
 
+  # Mammoth client encoded JWT is required as Authorized Bearer header
+  def require_mammoth!
+    header = request.headers['Authorization']
+    header = header.split.last if header
+    begin
+      @decoded = JsonToken.decode(header)
+      # @current_user = User.find(@decoded[:acct])
+    rescue ActiveRecord::RecordNotFound => e
+      render json: { errors: e.message }, status: 404
+    rescue JWT::DecodeError => e
+      render json: { errors: e.message }, status: 422
+    end
+  end
+
   def render_empty
     render json: {}, status: 200
   end

--- a/app/controllers/api/v3/channels_controller.rb
+++ b/app/controllers/api/v3/channels_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Api::V3::ChannelsController < Api::BaseController
+  before_action :require_mammoth!
+
   rescue_from Mammoth::Channels::NotFound do |e|
     render json: { error: e.to_s }, status: 404
   end

--- a/app/controllers/api/v3/timelines/for_you_controller.rb
+++ b/app/controllers/api/v3/timelines/for_you_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Api::V3::Timelines::ForYouController < Api::BaseController
+  before_action :require_mammoth!
   before_action :set_for_you_default, only: [:show]
 
   after_action :insert_pagination_headers, only: [:show], unless: -> { @statuses.empty? }

--- a/app/lib/json_token.rb
+++ b/app/lib/json_token.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Mammoth Generated JWT Token Decrypt
+# If no MAMMOTH_SECRET_KEY is set, decode is bypassed entirely.
+class JsonToken
+  SECRET_KEY = ENV.fetch('MAMMOTH_SECRET_KEY', nil)
+
+  def self.decode(token)
+    return unless SECRET_KEY
+    decoded = JWT.decode(token, SECRET_KEY)[0]
+    ActiveSupport::HashWithIndifferentAccess.new decoded
+  end
+end


### PR DESCRIPTION
## Requires a generated JWT on Mammoth, using a shared secret with the backend

* Enable server side, once the shared secret is in place, and mastodon web service is restarted. 
* Requires a shared secret embedded in the client and known to the server
* The secret itself is never transmitted from client to server. Only the generated JWT value
* Server will decode generated JWT for validation.