### PR TITLE
MAM-2789-when-adding-subscribed-channels-to-a-users-for-you-feed-well-need

### DIFF
--- a/app/controllers/api/v3/timelines/for_you_controller.rb
+++ b/app/controllers/api/v3/timelines/for_you_controller.rb
@@ -138,6 +138,7 @@ class Api::V3::Timelines::ForYouController < Api::BaseController
   def for_you_params
     params.permit(
       :acct,
+      [enabled_channels: []],
       :curated_by_mammoth,
       :friends_of_friends,
       :from_your_channels,

--- a/app/lib/personal_for_you.rb
+++ b/app/lib/personal_for_you.rb
@@ -108,7 +108,7 @@ class PersonalForYou
     Status.where(account_id: account_ids, updated_at: 12.hours.ago..Time.current).limit(200)
   end
 
-  # Get subscribed channels with full accounts
+  # Get enabled channels with full accounts
   # Fetch statuses for those accounts
   def statuses_for_enabled_channels(user)
     channels = Mammoth::Channels.new

--- a/app/lib/personal_for_you.rb
+++ b/app/lib/personal_for_you.rb
@@ -110,11 +110,24 @@ class PersonalForYou
 
   # Get subscribed channels with full accounts
   # Fetch statuses for those accounts
-  def statuses_for_subscribed_channels(user)
+  def statuses_for_enabled_channels(user)
     channels = Mammoth::Channels.new
-    subscribed_channels = subscribed_channels(user)
+    enabled_channels = enabled_channels(user)
 
-    channels.select_channels_with_statuses(subscribed_channels)
+    channels.select_channels_with_statuses(enabled_channels)
+  end
+
+  # Only include channels from user has enabled
+  # Return channels with full account details array
+  # User's subscribed array from `/me` only has channel summary
+  def enabled_channels(user)
+    channels = mammoth_channels
+    for_you_settings = user[:for_you_settings]
+    enabled_channel_ids = for_you_settings[:enabled_channels]
+
+    channels.filter do |channel|
+      enabled_channel_ids.include?(channel[:id])
+    end
   end
 
   # Only include channels from user subscribed

--- a/app/workers/update_for_you_worker.rb
+++ b/app/workers/update_for_you_worker.rb
@@ -89,11 +89,12 @@ class UpdateForYouWorker
   end
 
   # Channels Subscribed
+  # Include ONLY enabled_channels
   def push_channels_status
     user_setting = @user[:for_you_settings]
     return if user_setting[:from_your_channels].zero?
 
-    @personal.statuses_for_subscribed_channels(@user)
+    @personal.statuses_for_enabled_channels(@user)
              .filter_map { |s| engagment_threshold(s, user_setting[:from_your_channels], 'channel') }
              .each { |s| ForYouFeedWorker.perform_async(s['id'], @account.id, 'personal') }
   end


### PR DESCRIPTION
* ForYou Feed will filter channels from `enabled_channels` instead of subscribed channels

```bash
curl --location --request PUT 'https://staging.moth.social/api/v3/timelines/for_you/me?acct=jtomchak%40moth.social' \
--header 'Authorization: Bearer XXX' \
--form 'from_your_channels="0"' \
--form 'friends_of_friends="0"' \
--form 'curated_by_mammoth="1"' \
--form 'your_follows="0"' \
--form 'enabled_channels[]="8c4e6da2-ef00-443e-b8bd-427bdc5c145b"' \
--form 'enabled_channels[]="b8d94332-f4ee-4195-98ae-ec5be9233efe"'
```

> [!WARNING]  
> No selection requires 
```
--form 'enabled_channels[]="false"' \
```