### PR TITLE
MAM-2857-over-flow-on-pull-queue

### DIFF
--- a/app/workers/for_you_feed_worker.rb
+++ b/app/workers/for_you_feed_worker.rb
@@ -7,7 +7,7 @@ class ForYouFeedWorker
   include Redisable
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'pull', retry: 0
+  sidekiq_options queue: 'mammoth', retry: 0
 
   MAX_ITEMS = 1000
   MINIMUM_ENGAGMENT_ACTIONS = 2

--- a/app/workers/scheduler/for_you_statuses_scheduler.rb
+++ b/app/workers/scheduler/for_you_statuses_scheduler.rb
@@ -13,7 +13,7 @@ class Scheduler::ForYouStatusesScheduler
   include Sidekiq::Worker
   include JsonLdHelper
 
-  sidekiq_options retry: 0
+  sidekiq_options retry: 0, queue: 'mammoth'
 
   def perform
     owner_account = Account.local.where(username: FOR_YOU_OWNER_ACCOUNT)

--- a/app/workers/update_for_you_worker.rb
+++ b/app/workers/update_for_you_worker.rb
@@ -4,7 +4,7 @@ class UpdateForYouWorker
   include Redisable
   include Sidekiq::Worker
 
-  sidekiq_options retry: 0, queue: 'pull'
+  sidekiq_options retry: 0, queue: 'mammoth'
 
   # Mammoth Curated List(OG List)
 

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -7,6 +7,7 @@
   - [mailers, 2]
   - [pull]
   - [scheduler]
+  - [mammoth]
 :scheduler:
   :listened_queues_only: true
 :schedule:

--- a/dist/mastodon-sidekiq-mammoth.service
+++ b/dist/mastodon-sidekiq-mammoth.service
@@ -1,0 +1,53 @@
+[Unit]
+Description=mastodon-sidekiq
+After=network.target
+
+[Service]
+Type=simple
+User=mastodon
+WorkingDirectory=/home/mastodon/live
+Environment="RAILS_ENV=production"
+Environment="DB_POOL=5"
+Environment="MALLOC_ARENA_MAX=2"
+Environment="LD_PRELOAD=libjemalloc.so"
+ExecStart=/usr/bin/bash -l -c '/home/mastodon/.rbenv/shims/bundle exec sidekiq -e production -c $DB_POOL -q mammoth'
+TimeoutSec=15
+Restart=always
+# Proc filesystem
+ProcSubset=pid
+ProtectProc=invisible
+# Capabilities
+CapabilityBoundingSet=
+# Security
+NoNewPrivileges=true
+# Sandboxing
+ProtectSystem=strict
+PrivateTmp=true
+PrivateDevices=true
+PrivateUsers=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+RestrictAddressFamilies=AF_INET
+RestrictAddressFamilies=AF_INET6
+RestrictAddressFamilies=AF_NETLINK
+RestrictAddressFamilies=AF_UNIX
+RestrictNamespaces=true
+LockPersonality=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+RemoveIPC=true
+PrivateMounts=true
+ProtectClock=true
+# System Call Filtering
+SystemCallArchitectures=native
+SystemCallFilter=~@cpu-emulation @debug @keyring @ipc @mount @obsolete @privileged @setuid
+SystemCallFilter=@chown
+SystemCallFilter=pipe
+SystemCallFilter=pipe2
+ReadWritePaths=/home/mastodon/live
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This creates a queue specific to Mammoth work. Used solely in processing ForYou feed updates etc. 

Sidekiq queues `mammoth1` & `mammoth2` have both been created, enabled, and started on PROD in preperation

![Firefox Developer Edition 2023-10-03 at 17 16 23@2x](https://github.com/TheBLVD/moth.social/assets/76360/0733e9d0-9962-4934-944f-4e112976c4f2)
