### PR TITLE
MAM-2878make-call-for-waitlist-status-be

### DIFF
--- a/app/controllers/api/v3/timelines/for_you_controller.rb
+++ b/app/controllers/api/v3/timelines/for_you_controller.rb
@@ -7,7 +7,7 @@ class Api::V3::Timelines::ForYouController < Api::BaseController
   after_action :insert_pagination_headers, only: [:show], unless: -> { @statuses.empty? }
 
   def index
-    result = PersonalForYou.new.user(acct_param)
+    result = PersonalForYou.new.mammoth_user(acct_param)
     render json: result
   end
 

--- a/dist/mastodon-sidekiq-scheduler.service
+++ b/dist/mastodon-sidekiq-scheduler.service
@@ -7,7 +7,7 @@ Type=simple
 User=mastodon
 WorkingDirectory=/home/mastodon/live
 Environment="RAILS_ENV=production"
-Environment="DB_POOL=5"
+Environment="DB_POOL=10"
 Environment="MALLOC_ARENA_MAX=2"
 Environment="LD_PRELOAD=libjemalloc.so"
 ExecStart=/usr/bin/bash -l -c '/home/mastodon/.rbenv/shims/bundle exec sidekiq -e production -c $DB_POOL -q scheduler'


### PR DESCRIPTION
When getting for_you_settings, if not already 'personal' then check the user's waitlist status. 