### PR TITLE
MAM-2669-breadcrumbs-and-transparency-foryou-posts

### DIFF
--- a/app/controllers/api/v3/channels_controller.rb
+++ b/app/controllers/api/v3/channels_controller.rb
@@ -25,9 +25,12 @@ class Api::V3::ChannelsController < Api::BaseController
     render json: @user
   end
 
+  # Trigger user rebuild when unsubscribing from channel
+  # this is to clear out unwanted content from FY Feed
   def unsubscribe
     @mammoth = Mammoth::Channels.new
     @user = @mammoth.unsubscribe(channel_id_param, acct_param)
+    UpdateForYouWorker.perform_async({ acct: acct_param, rebuild: true })
     render json: @user
   end
 

--- a/app/controllers/api/v3/timelines/statuses_controller.rb
+++ b/app/controllers/api/v3/timelines/statuses_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class Api::V3::Timelines::StatusesController < Api::BaseController
+  before_action :set_status
+
+  def show
+    render json: { id: status_id_param }
+  end
+
+  private
+
+  def set_status; end
+
+  def status_id_param
+    params.require(:id)
+  end
+end

--- a/app/controllers/api/v3/timelines/statuses_controller.rb
+++ b/app/controllers/api/v3/timelines/statuses_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Api::V3::Timelines::StatusesController < Api::BaseController
+  before_action :require_mammoth!
+
   rescue_from Mammoth::StatusOrigin::NotFound do |e|
     render json: { error: e.to_s }, status: 404
   end

--- a/app/controllers/api/v3/timelines/statuses_controller.rb
+++ b/app/controllers/api/v3/timelines/statuses_controller.rb
@@ -1,15 +1,17 @@
 # frozen_string_literal: true
 
 class Api::V3::Timelines::StatusesController < Api::BaseController
-  before_action :set_status
+  rescue_from Mammoth::StatusOrigin::NotFound do |e|
+    render json: { error: e.to_s }, status: 404
+  end
 
   def show
-    render json: { id: status_id_param }
+    origin = Mammoth::StatusOrigin.instance
+    @origins = origin.find(status_id_param)
+    render json: @origins, each_serializer: StatusOriginSerializer
   end
 
   private
-
-  def set_status; end
 
   def status_id_param
     params.require(:id)

--- a/app/lib/mammoth/channels.rb
+++ b/app/lib/mammoth/channels.rb
@@ -13,7 +13,7 @@ module Mammoth
     def channels_with_statuses
       list(include_accounts: true).each do |channel|
         account_ids = account_ids(channel[:accounts])
-        channel[:statuses] = statuses_from_channel_accounts(account_ids)
+        channel[:statuses] = statuses_from_channels(account_ids)
       end
     end
 
@@ -24,14 +24,19 @@ module Mammoth
       origin = Mammoth::StatusOrigin.instance
       channels.flat_map do |channel|
         account_ids = account_ids(channel[:accounts])
-        statuses_from_channel_accounts(account_ids).filter_map { |s| engagment_threshold(s, channel[:fy_engagement_threshold]) }
-                                                   .each { |s| origin.add_channel(s, channel) }
+        statuses_with_accounts_from_channels(account_ids).filter_map { |s| engagment_threshold(s, channel[:fy_engagement_threshold]) }
+                                                         .each { |s| origin.add_channel(s, channel) }
       end
     end
 
-    def statuses_from_channel_accounts(account_ids)
+    def statuses_from_channels(account_ids)
       Status.where(account_id: account_ids,
                    created_at: (GO_BACK.hours.ago)..Time.current)
+    end
+
+    def statuses_with_accounts_from_channels(account_ids)
+      Status.includes([:account]).where(account_id: account_ids,
+                                        created_at: (GO_BACK.hours.ago)..Time.current)
     end
 
     # Check status for Channel's set level of engagment

--- a/app/lib/mammoth/channels.rb
+++ b/app/lib/mammoth/channels.rb
@@ -21,9 +21,11 @@ module Mammoth
     # Get Statuses from array of channels
     # filter out based on per channel threshold
     def select_channels_with_statuses(channels)
+      origin = Mammoth::StatusOrigin.instance
       channels.flat_map do |channel|
         account_ids = account_ids(channel[:accounts])
         statuses_from_channel_accounts(account_ids).filter_map { |s| engagment_threshold(s, channel[:fy_engagement_threshold]) }
+                                                   .each { |s| origin.add_channel(s, channel) }
       end
     end
 

--- a/app/lib/mammoth/status_origin.rb
+++ b/app/lib/mammoth/status_origin.rb
@@ -25,7 +25,7 @@ module Mammoth
         results = redis.smembers(list_key).map { |o| 
             payload = Oj.load(o, symbol_keys: true)
             originating_account = Account.create(payload[:originating_account])
-            origin = ::StatusOrigin.new(source: payload[:source], id: payload[:id], title: payload[:title], originating_account:originating_account )
+            origin = ::StatusOrigin.new(source: payload[:source], channel_id: payload[:id], title: payload[:title], originating_account:originating_account )
             Rails.logger.debug "AR:: ACCOUNT  #{originating_account}"
             Rails.logger.debug "AR:: ORIGIN  #{origin}"
             origin
@@ -47,7 +47,7 @@ module Mammoth
     end
 
     def channel_reason(status, channel)
-        Oj.dump({source: "SmartList", id: status[:id], title: channel[:title], originating_account: status.account})
+        Oj.dump({source: "SmartList", channel_id: channel[:id], title: channel[:title], originating_account: status.account})
     end
   end
 end

--- a/app/lib/mammoth/status_origin.rb
+++ b/app/lib/mammoth/status_origin.rb
@@ -16,16 +16,28 @@ module Mammoth
         reason = channel_reason(status, channel)
         
         # Expire Reason in 7 days
-        redis.sadd(list_key, reason)
-        redis.expire(list_key, 7.day.seconds) 
+        add_reason(list_key, reason)
     end
+
+    def add_mammoth_pick(status)
+        list_key = key(status[:id])
+        reason = mammoth_pick_reason(status)
+
+        add_reason(list_key, reason)
+    end 
+
+    def add_reason(key, reason)
+        # Expire Reason in 7 days
+        redis.sadd(key, reason)
+        redis.expire(key, 7.day.seconds) 
+    end 
 
     def find(status_id)
         list_key = key(status_id)
         results = redis.smembers(list_key).map { |o| 
             payload = Oj.load(o, symbol_keys: true)
             originating_account = Account.create(payload[:originating_account])
-            origin = ::StatusOrigin.new(source: payload[:source], channel_id: payload[:id], title: payload[:title], originating_account:originating_account )
+            origin = ::StatusOrigin.new(source: payload[:source], channel_id: payload[:channel_id], title: payload[:title], originating_account:originating_account )
             Rails.logger.debug "AR:: ACCOUNT  #{originating_account}"
             Rails.logger.debug "AR:: ORIGIN  #{origin}"
             origin
@@ -48,6 +60,10 @@ module Mammoth
 
     def channel_reason(status, channel)
         Oj.dump({source: "SmartList", channel_id: channel[:id], title: channel[:title], originating_account: status.account})
+    end
+
+    def mammoth_pick_reason(status)
+        Oj.dump({source: "MammothPick", originating_account: status.account })
     end
   end
 end

--- a/app/lib/mammoth/status_origin.rb
+++ b/app/lib/mammoth/status_origin.rb
@@ -26,8 +26,9 @@ module Mammoth
         add_reason(list_key, reason)
     end 
 
+    # Add reason by key id
+    # Expire Reason in 7 days
     def add_reason(key, reason)
-        # Expire Reason in 7 days
         redis.sadd(key, reason)
         redis.expire(key, 7.day.seconds) 
     end 

--- a/app/lib/mammoth/status_origin.rb
+++ b/app/lib/mammoth/status_origin.rb
@@ -43,8 +43,8 @@ module Mammoth
             Rails.logger.debug "AR:: ORIGIN  #{origin}"
             origin
     }
-        Rails.logger.debug "RESULT:: #{results}"
-
+        # Throw Error if array find is empty
+        raise NotFound, 'status not found' unless results.length > 0 
         return results
     end 
 

--- a/app/lib/mammoth/status_origin.rb
+++ b/app/lib/mammoth/status_origin.rb
@@ -16,7 +16,7 @@ module Mammoth
         reason = channel_reason(status, channel)
         
         # Expire Reason in 7 days
-        redis.sadd(list_key, channel[:id], reason)
+        redis.sadd(list_key, reason)
         redis.expire(list_key, 7.day.seconds) 
     end
 
@@ -25,7 +25,7 @@ module Mammoth
         results = redis.smembers(list_key).map { |o| 
             payload = Oj.load(o, symbol_keys: true)
             originating_account = Account.create(payload[:originating_account])
-            origin = ::StatusOrigin.new(source: payload[:source], title: payload[:title], originating_account:originating_account )
+            origin = ::StatusOrigin.new(source: payload[:source], id: payload[:id], title: payload[:title], originating_account:originating_account )
             Rails.logger.debug "AR:: ACCOUNT  #{originating_account}"
             Rails.logger.debug "AR:: ORIGIN  #{origin}"
             origin

--- a/app/lib/mammoth/status_origin.rb
+++ b/app/lib/mammoth/status_origin.rb
@@ -15,7 +15,6 @@ module Mammoth
         list_key = key(status[:id])
         reason = channel_reason(status, channel)
         
-        # Expire Reason in 7 days
         add_reason(list_key, reason)
     end
 
@@ -38,10 +37,8 @@ module Mammoth
         results = redis.smembers(list_key).map { |o| 
             payload = Oj.load(o, symbol_keys: true)
             originating_account = Account.create(payload[:originating_account])
-            origin = ::StatusOrigin.new(source: payload[:source], channel_id: payload[:channel_id], title: payload[:title], originating_account:originating_account )
-            Rails.logger.debug "AR:: ACCOUNT  #{originating_account}"
-            Rails.logger.debug "AR:: ORIGIN  #{origin}"
-            origin
+            # StatusOrigin Active Model for serialization
+            ::StatusOrigin.new(source: payload[:source], channel_id: payload[:channel_id], title: payload[:title], originating_account:originating_account )
     }
         # Throw Error if array find is empty
         raise NotFound, 'status not found' unless results.length > 0 

--- a/app/lib/mammoth/status_origin.rb
+++ b/app/lib/mammoth/status_origin.rb
@@ -15,10 +15,9 @@ module Mammoth
         list_key = key(status[:id])
         reason = channel_reason(status, channel)
         
+        # Expire Reason in 7 days
         redis.sadd(list_key,reason)
-        
-        # Keep the list from growning infinitely
-        # trim(timeline_key, account_id)
+        redis.expire(list_key, 7.day.seconds) 
     end
 
     private 
@@ -29,12 +28,11 @@ module Mammoth
     # @return [String]
     def key(id, subtype = nil)
     return "origin:for_you:#{id}" unless subtype
-
     "origin:for_you:#{id}:#{subtype}"
     end
 
     def channel_reason(status, channel)
-        Oj.dump({source: "SmartList", title: channel[:title], originating_account: status[:account]})
+        Oj.dump({source: "SmartList", title: channel[:title], originating_account: status.account})
     end
   end
 end

--- a/app/lib/mammoth/status_origin.rb
+++ b/app/lib/mammoth/status_origin.rb
@@ -34,7 +34,7 @@ module Mammoth
     end
 
     def channel_reason(status, channel)
-        OJ.dump({source: "SmartList", title: channel[:title], originating_account: status[:account]})
+        Oj.dump({source: "SmartList", title: channel[:title], originating_account: status[:account]})
     end
   end
 end

--- a/app/lib/mammoth/status_origin.rb
+++ b/app/lib/mammoth/status_origin.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+# rubocop:disable all
+require 'singleton'
+
+module Mammoth
+
+    class StatusOrigin
+        include Singleton
+        include Redisable
+    class NotFound < StandardError; end
+
+    
+    # Add Status and Reason to list
+    def add_channel(status, channel)
+        list_key = key(status[:id])
+        reason = channel_reason(status, channel)
+        
+        redis.sadd(list_key,reason)
+        
+        # Keep the list from growning infinitely
+        # trim(timeline_key, account_id)
+    end
+
+    private 
+
+    # Redis key of a status
+    # @param [Integer] status id
+    # @param [Symbol] subtype
+    # @return [String]
+    def key(id, subtype = nil)
+    return "origin:for_you:#{id}" unless subtype
+
+    "origin:for_you:#{id}:#{subtype}"
+    end
+
+    def channel_reason(status, channel)
+        OJ.dump({source: "SmartList", title: channel[:title], originating_account: status[:account]})
+    end
+  end
+end

--- a/app/models/status_origin.rb
+++ b/app/models/status_origin.rb
@@ -2,7 +2,7 @@ class StatusOrigin
   include ActiveModel::Model
   include ActiveModel::Serialization
 
-  attr_accessor :source, :title, :originating_account
+  attr_accessor :source, :id, :title, :originating_account
 
   def initialize(attributes = {})
     super

--- a/app/models/status_origin.rb
+++ b/app/models/status_origin.rb
@@ -2,7 +2,7 @@ class StatusOrigin
   include ActiveModel::Model
   include ActiveModel::Serialization
 
-  attr_accessor :source, :id, :title, :originating_account
+  attr_accessor :source, :channel_id, :title, :originating_account
 
   def initialize(attributes = {})
     super

--- a/app/models/status_origin.rb
+++ b/app/models/status_origin.rb
@@ -1,0 +1,11 @@
+class StatusOrigin
+  include ActiveModel::Model
+  include ActiveModel::Serialization
+
+  attr_accessor :source, :title, :originating_account
+
+  def initialize(attributes = {})
+    super
+  end
+  # belongs_to :originating_account, class_name: 'Account'
+end

--- a/app/models/status_origin.rb
+++ b/app/models/status_origin.rb
@@ -1,3 +1,4 @@
+# ActiveModel Only for Serialization
 class StatusOrigin
   include ActiveModel::Model
   include ActiveModel::Serialization
@@ -7,5 +8,4 @@ class StatusOrigin
   def initialize(attributes = {})
     super
   end
-  # belongs_to :originating_account, class_name: 'Account'
 end

--- a/app/serializers/status_origin_serializer.rb
+++ b/app/serializers/status_origin_serializer.rb
@@ -1,5 +1,5 @@
 class StatusOriginSerializer < ActiveModel::Serializer
-  attributes :source, :title, :id
+  attributes :source, :title, :channel_id
 
   belongs_to :originating_account, serializer: REST::AccountSerializer
 end

--- a/app/serializers/status_origin_serializer.rb
+++ b/app/serializers/status_origin_serializer.rb
@@ -1,3 +1,5 @@
+# Required Source & Originating Account
+# Channel_id & Title maybe be null
 class StatusOriginSerializer < ActiveModel::Serializer
   attributes :source, :title, :channel_id
 

--- a/app/serializers/status_origin_serializer.rb
+++ b/app/serializers/status_origin_serializer.rb
@@ -1,5 +1,5 @@
 class StatusOriginSerializer < ActiveModel::Serializer
-  attributes :source, :title
+  attributes :source, :title, :id
 
   belongs_to :originating_account, serializer: REST::AccountSerializer
 end

--- a/app/serializers/status_origin_serializer.rb
+++ b/app/serializers/status_origin_serializer.rb
@@ -1,0 +1,5 @@
+class StatusOriginSerializer < ActiveModel::Serializer
+  attributes :source, :title
+
+  belongs_to :originating_account, serializer: REST::AccountSerializer
+end

--- a/app/workers/update_for_you_worker.rb
+++ b/app/workers/update_for_you_worker.rb
@@ -104,9 +104,13 @@ class UpdateForYouWorker
 
     curated_list = Mammoth::CuratedList.new
     list_statuses = curated_list.curated_list_statuses
+    origin = Mammoth::StatusOrigin
 
     list_statuses.filter_map { |s| engagment_threshold(s, user_setting[:curated_by_mammoth], 'mammoth') }
-                 .each { |s| ForYouFeedWorker.perform_async(s['id'], @account.id, 'personal') }
+                 .each do |s|
+      origin.add_mammoth_pick(s)
+      ForYouFeedWorker.perform_async(s['id'], @account.id, 'personal')
+    end
   end
 
   # Check status for User's level of engagment

--- a/app/workers/update_for_you_worker.rb
+++ b/app/workers/update_for_you_worker.rb
@@ -104,7 +104,7 @@ class UpdateForYouWorker
 
     curated_list = Mammoth::CuratedList.new
     list_statuses = curated_list.curated_list_statuses
-    origin = Mammoth::StatusOrigin
+    origin = Mammoth::StatusOrigin.instance
 
     list_statuses.filter_map { |s| engagment_threshold(s, user_setting[:curated_by_mammoth], 'mammoth') }
                  .each do |s|

--- a/app/workers/update_for_you_worker.rb
+++ b/app/workers/update_for_you_worker.rb
@@ -94,9 +94,7 @@ class UpdateForYouWorker
     user_setting = @user[:for_you_settings]
     return if user_setting[:from_your_channels].zero?
 
-    @personal.statuses_for_enabled_channels(@user)
-             .filter_map { |s| engagment_threshold(s, user_setting[:from_your_channels], 'channel') }
-             .each { |s| ForYouFeedWorker.perform_async(s['id'], @account.id, 'personal') }
+    @personal.statuses_for_enabled_channels(@user).each { |s| ForYouFeedWorker.perform_async(s['id'], @account.id, 'personal') }
   end
 
   # Mammoth Curated OG List

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -725,6 +725,7 @@ Rails.application.routes.draw do
       namespace :timelines do
         resources :channels, only: :show, controller: :channels
         resource :for_you, only: [:show], controller: 'for_you' do
+          resources :statuses, only: :show, controller: :statuses
           get '/me',      to: 'for_you#index'
           put '/me',      to: 'for_you#update'
         end   

--- a/spec/fabricators/status_origin_fabricator.rb
+++ b/spec/fabricators/status_origin_fabricator.rb
@@ -1,0 +1,4 @@
+Fabricator(:status_origin) do
+  source "MyString"
+  title  "MyString"
+end

--- a/spec/models/status_origin_spec.rb
+++ b/spec/models/status_origin_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe StatusOrigin, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
* save origin reason when adding status to a user's for you feed
* fetch status origin api GET `https://staging.moth.social/api/v3/timelines/for_you/statuses/11129536085876024`
* Trigger rebuild of FY when unsubscribing from smartlist

```json
[
    {
        "source": "SmartList",
        "title": "Info Researchers",
        "channel_id": "0549325f-9e32-45bf-89a8-8fecb239d71f",
        "originating_account": {
            "id": "109902962269738889",
            "username": "mszll",
            "acct": "mszll@datasci.social",
```

`source` currently includes 'SmartList' | 'MammothPick'