### PR TITLE
 MAM-2930-make-a-new-endpoint-for-a-list-of-grouped-onboarding-accounts

### DIFF
--- a/app/controllers/api/v2/follow_recommendations_graph_controller.rb
+++ b/app/controllers/api/v2/follow_recommendations_graph_controller.rb
@@ -29,9 +29,12 @@ class Api::V2::FollowRecommendationsGraphController < Api::BaseController
   def set_account
     if acct_is_personalized?
       username, domain = username_and_domain(params[:acct])
-      return not_found unless TagManager.instance.local_domain?(domain)
 
-      @account = Account.find_local(username) || Account.find_remote(handle_to_account_remote)
+      @account = if TagManager.instance.local_domain?(domain)
+                   Account.find_local(username)
+                 else
+                   Account.find_remote(username, domain)
+                 end
     else
       onboarding_accounts = OnboardingAccountRecommendationsService.new
       render json: onboarding_accounts.call, each_serializer: REST::AccountSerializer

--- a/app/controllers/api/v2/follow_recommendations_graph_controller.rb
+++ b/app/controllers/api/v2/follow_recommendations_graph_controller.rb
@@ -23,9 +23,8 @@ class Api::V2::FollowRecommendationsGraphController < Api::BaseController
 
   private
 
-  # Parse acct parameter
-  # return account if personalized
-  # return onboarding account suggestions of acct type is 'public'
+  # return account if local user
+  # return 404 if not a local user
   def set_account
     username, domain = username_and_domain(params[:acct])
     return not_found unless TagManager.instance.local_domain?(domain)

--- a/app/controllers/api/v2/follow_recommendations_graph_controller.rb
+++ b/app/controllers/api/v2/follow_recommendations_graph_controller.rb
@@ -27,18 +27,10 @@ class Api::V2::FollowRecommendationsGraphController < Api::BaseController
   # return account if personalized
   # return onboarding account suggestions of acct type is 'public'
   def set_account
-    if acct_is_personalized?
-      username, domain = username_and_domain(params[:acct])
+    username, domain = username_and_domain(params[:acct])
+    return not_found unless TagManager.instance.local_domain?(domain)
 
-      @account = if TagManager.instance.local_domain?(domain)
-                   Account.find_local(username)
-                 else
-                   Account.find_remote(username, domain)
-                 end
-    else
-      onboarding_accounts = OnboardingAccountRecommendationsService.new
-      render json: onboarding_accounts.call, each_serializer: REST::AccountSerializer
-    end
+    @account = Account.find_local(username)
   end
 
   def acct_is_personalized?

--- a/app/controllers/api/v2/follow_recommendations_graph_controller.rb
+++ b/app/controllers/api/v2/follow_recommendations_graph_controller.rb
@@ -32,10 +32,6 @@ class Api::V2::FollowRecommendationsGraphController < Api::BaseController
     @account = Account.find_local(username)
   end
 
-  def acct_is_personalized?
-    PersonalForYou.new.personalized_mammoth_user?(params[:acct])
-  end
-
   def handle_to_account_remote(handle)
     username, domain = username_and_domain(handle)
     Account.find_remote(username, domain)

--- a/app/controllers/api/v2/onboarding_follow_recommendations_controller.rb
+++ b/app/controllers/api/v2/onboarding_follow_recommendations_controller.rb
@@ -11,8 +11,10 @@ class Api::V2::OnboardingFollowRecommendationsController < Api::BaseController
     render json: onboarding_follows.call, each_serializer: REST::V2::FollowRecommendationCategorySerializer
   end
 
+  # OnboardingAccountRecommendationsService returns the same YAML list
+  # but only accounts, no hashtags. only grouped accounts.
   def accounts
     onboarding_accounts = OnboardingAccountRecommendationsService.new
-    render json: onboarding_accounts.call, each_serializer: REST::AccountSerializer
+    render json: onboarding_accounts.call, each_serializer: REST::V2::FollowRecommendationCategorySerializer
   end
 end

--- a/app/controllers/api/v2/onboarding_follow_recommendations_controller.rb
+++ b/app/controllers/api/v2/onboarding_follow_recommendations_controller.rb
@@ -10,4 +10,9 @@ class Api::V2::OnboardingFollowRecommendationsController < Api::BaseController
     onboarding_follows = OnboardingFollowRecommendationsService.new
     render json: onboarding_follows.call, each_serializer: REST::V2::FollowRecommendationCategorySerializer
   end
+
+  def accounts
+    onboarding_accounts = OnboardingAccountRecommendationsService.new
+    render json: onboarding_accounts.call, each_serializer: REST::AccountSerializer
+  end
 end

--- a/app/lib/onboarding/v2/onboarding_categories_development.yml
+++ b/app/lib/onboarding/v2/onboarding_categories_development.yml
@@ -7,6 +7,254 @@
     - account: '@daily@moth.social'
       type: account
       summary: Light-hearted and wholesome content.
+- name: Celebrities & Pop Culture
+  items:
+    - account: '@elonjet@mastodon.social'
+      type: account
+      summary: The official ElonJet account.
+    - account: '@MarkRuffalo@mastodon.social'
+      type: account
+      summary: Award-winning actor, Oscar nominee.
+    - account: '@georgetakei@universeodon.com'
+      type: account
+      summary: "Actor, author, and activist. \U0001F596"
+    - hashtag: '#popculture'
+      type: hashtag
+      bio: Pop culture discussion; celebrities, news, etc.
+      summary: General pop culture.
+    - account: '@neilhimself@mastodon.social'
+      type: account
+      summary: English author of fiction, novels.
+    - account: '@alexwinter@mastodon.social'
+      type: account
+      summary: Actor and filmmaker.
+    - hashtag: '#movies'
+      type: hashtag
+      bio: General movies and film discussion.
+      summary: Movies discussion.
+    - account: '@morgfair@newsie.social'
+      type: account
+      summary: Actress, Primetime Emmy nominee.
+    - account: '@BethanyBlack@mastodon.social'
+      type: account
+      summary: English stand-up comedian.
+    - account: '@jquillin@fashionsocial.host'
+      type: account
+      summary: Glass Magazine Fmr Fashion editor.
+    - hashtag: '#throwbackthursday'
+      type: hashtag
+      bio: Nostalgia posts and old pop-culture, every Thursday.
+      summary: Throwback Thursday!
+- name: Journalists & Publications
+  items:
+    - account: '@Sheril@mastodon.social'
+      type: account
+      summary: Author, scientist, PBS host.
+    - account: '@Techmeme@techhub.social'
+      type: account
+      summary: Top tech news and commentary.
+    - hashtag: '#journalism'
+      type: hashtag
+      bio: Discussion and news regarding journalism, and journalists.
+      summary: Journalists and journalism news.
+    - account: '@RollingStone@mstdn.social'
+      type: account
+      summary: Rolling Stone magazine official account.
+    - account: '@w7voa@journa.host'
+      type: account
+      summary: VoA Chief National Correspondent.
+    - account: '@briankrebs@infosec.exchange'
+      type: account
+      summary: Cybercrime investigative journalist.
+    - account: '@drewharwell@mastodon.social'
+      type: account
+      summary: WaPo Technology Reporter.
+    - hashtag: '#media'
+      type: hashtag
+      bio: Discussion and news regarding mainstream and alternative media.
+      summary: Media-related discussion.
+    - account: '@damemagazine@newsie.social'
+      type: account
+      summary: Women-led, independent magazine.
+    - account: '@chrisgeidner@journa.host'
+      type: account
+      summary: Award-winning law journalist.
+    - account: '@Emilyalpertreyes@mas.to'
+      type: account
+      summary: LA Times covering Public Health.
+- name: Content Creators
+  items:
+    - account: '@rebeccawatson@mstdn.social'
+      type: account
+      summary: Feminist blogger and podcast host.
+    - account: '@TechConnectify@mas.to'
+      type: account
+      summary: Educational technology YouTuber.
+    - hashtag: '#blogging'
+      type: hashtag
+      bio: Discussion related to blogging, and interesting blog posts people have shared.
+      summary: Blog content and discussion.
+    - account: '@oatmeal@mastodon.social'
+      type: account
+      summary: Popular web comic by Matthew Inman.
+    - account: '@notjustbikes@notjustbikes.com'
+      type: account
+      summary: Urbanist commentator, YouTuber.
+    - hashtag: '#youtube'
+      type: hashtag
+      bio: Discussion related to the YouTube video website, YouTubers and YouTuber culture.
+      summary: YouTube-related discussion.
+- name: Tech & Business
+  items:
+    - account: '@anildash@me.dm'
+      type: account
+      summary: Technology entrepreneur.
+    - account: '@b0rk@jvns.ca'
+      type: account
+      summary: Software developer from Montreal.
+    - account: '@snazzyq@mas.to'
+      type: account
+      summary: Popular technology YouTuber.
+    - hashtag: '#apple'
+      type: hashtag
+      bio: Discussion related to the Apple company, products, services, and software.
+      summary: Apple-related discussion.
+    - account: '@donmelton@mstdn.social'
+      type: account
+      summary: Mastodon’s “Store Welcome Greeter”.
+    - account: '@caseynewton@mastodon.social'
+      type: account
+      summary: Tech journalist. Editor, Platformer.
+    - account: '@DetroitBORG@techhub.social'
+      type: account
+      summary: Popular Apple and tech YouTuber.
+    - hashtag: '#startup'
+      type: hashtag
+      bio: Discussion related to startups, entrepreneurship, and general industry happenings.
+      summary: Startups and entrepreneurship.
+    - account: '@craignewmark@mastodon.social'
+      type: account
+      summary: Founder of Craigslist.
+- name: Academics & Thinkers
+  items:
+    - account: '@helenprejean@mindly.social'
+      type: account
+      summary: Death penalty activist.
+    - account: '@thesiswhisperer@aus.social'
+      type: account
+      summary: Professor Inger Mewburn, ANU.
+    - hashtag: '#urbanism'
+      type: hashtag
+      bio: Discussion surrounding urbanism movements, transport and city planning.
+      summary: Urbanist news and discussion.
+    - account: '@drcaberry@blacktwitter.io'
+      type: account
+      summary: Elec. Engineering, Robotics professor.
+    - account: '@brooklynmarie@mastodon.social'
+      type: account
+      summary: Your friendly neighborhood debunker.
+    - hashtag: '#academia'
+      type: hashtag
+      bio: 'Academics on Mastodon: research, news, papers and general discussion.'
+      summary: Academia and academics.
+    - account: '@kityates@mas.to'
+      type: account
+      summary: Mathematical biologist, book author.
+    - account: '@absolutspacegrl@mastodon.social'
+      type: account
+      summary: NASA engineer.
+- name: Politics & Activism
+  items:
+    - account: '@RitchieTorres@universeodon.com'
+      type: account
+      summary: NY15 Congressman.
+    - account: '@rubenbolling@mastodon.social'
+      type: account
+      summary: Award winning political cartoonist.
+    - hashtag: '#Activism'
+      type: hashtag
+      bio: Discussion covering activism and activist movements across the world.
+      summary: General activism discussion.
+    - account: '@zhivi@blacktwitter.io'
+      type: account
+      summary: Health, fitness, accountability coach.
+    - hashtag: '#BlackLivesMatter'
+      type: hashtag
+      bio:
+        Discussion around the Black Lives Matter decentralized political and social
+        movement.
+      summary: Activism movement.
+    - account: '@RepShontelBrown@mastodon.social'
+      type: account
+      summary: OH11 Congresswoman.
+    - account: '@Tinu@mastodon.social'
+      type: account
+      summary: Digital community organiser.
+    - account: '@timnitGebru@dair-community.social'
+      type: account
+      summary: Founder, Distributed AI Research Institute.
+    - account: '@futurebird@sauropods.win'
+      type: account
+      summary: Sci-fi writer, mathematics, CS teacher.
+    - account: '@QasimRashid@mastodon.social'
+      type: account
+      summary: Human rights lawyer, author.
+    - account: '@TheWarOnCars@mastodon.social'
+      type: account
+      summary: Popular podcast on car dependency.
+    - hashtag: '#politics'
+      type: hashtag
+      bio: Political news and discussion, United States and worldwide.
+      summary: US & international politics.
+    - account: '@BigAngBlack@fosstodon.org'
+      type: account
+      summary: Black culture student.
+- name: Humor
+  items:
+    - account: '@feral_hattie@mastodon.social'
+      type: account
+      summary: Humorous posts with progressive themes.
+    - account: '@professorkiosk@beige.party'
+      type: account
+      summary: Comedic posts from an academic.
+    - account: '@Alice@beige.party'
+      type: account
+      summary: Witty one-liners.
+    - account: '@princesaballena@beige.party'
+      type: account
+      summary: Silly jokes and puns.
+- name: Art & Photographers
+  items:
+    - account: '@Curator@mastodon.art'
+      type: account
+      summary: The best of artists on Mastodon.
+    - account: '@pnwres@mastodon.scot'
+      type: account
+      summary: Professional pet photographer.
+    - account: '@ewen@photog.social'
+      type: account
+      summary: Australian editorial photographer.
+    - hashtag: '#mastoart'
+      type: hashtag
+      bio: Artists and art discussion, primarily from those who call Mastodon home.
+      summary: Artists on Mastodon.
+    - account: '@stevenlawson@photog.social'
+      type: account
+      summary: Scottish landscape photographer.
+    - hashtag: '#mosstodon'
+      type: hashtag
+      bio: One of the old-school Mastodon hashtags, calming pictures of moss.
+      summary: Moss on Mastodon. Mosstodon.
+    - account: '@ObsidianUrbex@photog.social'
+      type: account
+      summary: English urban explorer and photographer.
+    - account: '@ginaperry@socel.net'
+      type: account
+      summary: Children’s book author and illustrator.
+    - hashtag: '#photography'
+      type: hashtag
+      bio: Photographers and interesting photos on Mastodon.
+      summary: Photos and photography.
 - name: Mammoth Team
   items:
     - account: '@bart@moth.social'
@@ -27,3 +275,6 @@
     - account: '@jtomchak@moth.social'
       type: account
       summary: Engineer at Mammoth.
+    - account: '@pxl@moth.social'
+      type: account
+      summary: Designer at Mammoth.

--- a/app/lib/onboarding/v2/onboarding_categories_production.yml
+++ b/app/lib/onboarding/v2/onboarding_categories_production.yml
@@ -4,9 +4,6 @@
     - account: '@mammoth@moth.social'
       type: account
       summary: The official Mammoth account.
-    - account: '@daily@moth.social'
-      type: account
-      summary: Light-hearted and wholesome content.
 - name: Celebrities & Pop Culture
   items:
     - account: '@elonjet@mastodon.social'

--- a/app/services/follow_recommendations_service.rb
+++ b/app/services/follow_recommendations_service.rb
@@ -3,6 +3,9 @@
 # Returns an array of string user handles (eg: johndoe@mastodon.server) with follow recommendations
 # for the provided user, according to other users that are the most followed by their existing follows.
 class FollowRecommendationsService < BaseService
+  # We're making the assumption that these 3 accounts below exist in the local server and they
+  # represent the moth.social staff. Please keep this list up to date!
+  DEFAULT_FOLLOW_LIST = %w(mark bart misspurple).freeze
   MAX_RESULTS = 50
   DEFAULT_FOLLOW_LIMIT = 200
 
@@ -22,8 +25,8 @@ class FollowRecommendationsService < BaseService
     Rails.cache.fetch(cache_key, expires_in: 6.months, force: force) do
       direct_follows = account_follows(@handle).map(&:symbolize_keys)
       if direct_follows.empty?
-        Rails.logger.info("No follows found for #{@handle}, defaulting to `Onboarding recommendations accounts list`")
-        return generate_default_follows.map(&:symbolize_keys).pluck(:acct)
+        Rails.logger.info("No follows found for #{@handle}, defaulting to `DEFAULT_FOLLOW_LIST`")
+        direct_follows = generate_default_follows.map(&:symbolize_keys)
       end
       direct_follow_ids = Set.new(direct_follows.pluck(:acct))
       direct_follow_ids.add(@handle.sub(/^@/, ''))
@@ -81,10 +84,9 @@ class FollowRecommendationsService < BaseService
   end
 
   # Returns an array of default follows in the same JSON format as the public API using AccountSerializer
-  #
   def generate_default_follows
     # domain: nil makes sure we're looking for local accounts
-    accounts = OnboardingAccountRecommendationsService.new.call
+    accounts = Account.where(username: DEFAULT_FOLLOW_LIST, domain: nil)
     serializer = ActiveModel::Serializer::CollectionSerializer.new(
       accounts, serializer: REST::AccountSerializer
     )

--- a/app/services/onboarding_account_recommendations_service.rb
+++ b/app/services/onboarding_account_recommendations_service.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Returns an array of user accounts resolved from the onboard_follow_recommendations yml
+class OnboardingAccountRecommendationsService < BaseService
+  def call
+    generate_onboarding_account_recommendations
+  end
+
+  private
+
+  def generate_onboarding_account_recommendations
+    categories = YAML.load_file(yaml_file_location)
+    categories.flat_map do |category|
+      # If any of YML accounts are invalid or not found in the database, we'll omit them from the response
+      category['items'].filter_map do |item|
+        if item['type'] == 'hashtag'
+          next
+        elsif item['type'] == 'account'
+          account = find_account(item)
+          next if account.nil?
+
+          account
+        end
+      end
+    end
+  end
+
+  def find_account(account)
+    # TODO: this probably belongs in account_finder_concern.rb.
+    # I'm putting it here for now to avoid messing with mastodon code.
+    # if we need it elsewhere, we should move it. SD
+    username, domain = username_and_domain(account['account'])
+    Account.find_remote(username, domain) ||
+      Account.find_local(username)
+  end
+
+  def username_and_domain(handle)
+    username, domain = handle.strip.gsub(/\A@/, '').split('@')
+    [username, domain]
+  end
+
+  def yaml_file_location
+    Rails.root.join("app/lib/onboarding/v2/onboarding_categories_#{Rails.env}.yml").to_s
+  end
+end

--- a/app/services/onboarding_account_recommendations_service.rb
+++ b/app/services/onboarding_account_recommendations_service.rb
@@ -8,7 +8,7 @@ class OnboardingAccountRecommendationsService < BaseService
 
   private
 
-  def generate_onboarding_follow_recommendations
+  def generate_onboarding_account_recommendations
     categories = YAML.load_file(yaml_file_location)
     categories.map do |category|
       Onboarding::V2::FollowRecommendationCategory.new(

--- a/app/services/onboarding_account_recommendations_service.rb
+++ b/app/services/onboarding_account_recommendations_service.rb
@@ -14,8 +14,8 @@ class OnboardingAccountRecommendationsService < BaseService
       Onboarding::V2::FollowRecommendationCategory.new(
         name: category['name'],
         # If any of YML accounts are invalid or not found in the database, we'll omit them from the response
-        # Skip hashtags
         items: category['items'].filter_map do |item|
+          # Skip hashtags
           if item['type'] == 'hashtag'
             next
           elsif item['type'] == 'account'

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -307,7 +307,10 @@ namespace :api, format: false do
       resources :accounts, only: [:index]
     end
 
-    resources :onboarding_follow_recommendations, only: :index, controller: 'onboarding_follow_recommendations'
+    resource :onboarding_follow_recommendations, only: :index, controller: 'onboarding_follow_recommendations' do
+      get '/', to: 'onboarding_follow_recommendations#index'
+      get '/accounts', to: 'onboarding_follow_recommendations#accounts'
+    end
   end
 
   # V3 Mammoth


### PR DESCRIPTION
* Additional endpoint `/api/v2/onboarding_follow_recommendations/accounts` that will return only recommended accounts as an array. no hashtags or meta data

Try it out: https://staging.moth.social//api/v2/onboarding_follow_recommendations/accounts

Resolves MAM-2930 