### PR TITLE
 MAM-3127-discordsuggested-follows

### DIFF
--- a/app/controllers/api/v2/follow_recommendations_graph_controller.rb
+++ b/app/controllers/api/v2/follow_recommendations_graph_controller.rb
@@ -8,9 +8,8 @@ class Api::V2::FollowRecommendationsGraphController < Api::BaseController
   before_action :set_account
 
   def show
-    handle = @account.acct
     service = FollowRecommendationsService.new
-    recommendation_handles = service.call(handle: handle)
+    recommendation_handles = service.call(handle: @handle)
     follows = Follow.where(account: @account).map { |f| f.target_account.acct }
     recommendations = recommendation_handles
                       .reject { |recommendation| follows.include?(recommendation) }
@@ -31,6 +30,7 @@ class Api::V2::FollowRecommendationsGraphController < Api::BaseController
 
     domain = nil if domain == Rails.configuration.x.local_domain
     @account = Account.where(username: username, domain: domain).first
+    @handle = params[:acct]
   end
 
   def personalized?

--- a/app/controllers/api/v2/follow_recommendations_graph_controller.rb
+++ b/app/controllers/api/v2/follow_recommendations_graph_controller.rb
@@ -29,7 +29,8 @@ class Api::V2::FollowRecommendationsGraphController < Api::BaseController
     username, domain = username_and_domain(params[:acct])
     return not_found unless TagManager.instance.local_domain?(domain) || personalized?
 
-    @account = Account.find_local(username)
+    domain = nil if domain == Rails.configuration.x.local_domain
+    @account = Account.where(username: username, domain: domain).first
   end
 
   def personalized?

--- a/app/controllers/api/v2/follow_recommendations_graph_controller.rb
+++ b/app/controllers/api/v2/follow_recommendations_graph_controller.rb
@@ -8,7 +8,7 @@ class Api::V2::FollowRecommendationsGraphController < Api::BaseController
   before_action :set_account
 
   def show
-    handle = @account.local_username_and_domain
+    handle = @account.acct
     service = FollowRecommendationsService.new
     recommendation_handles = service.call(handle: handle)
     follows = Follow.where(account: @account).map { |f| f.target_account.acct }

--- a/app/controllers/api/v2/follow_recommendations_graph_controller.rb
+++ b/app/controllers/api/v2/follow_recommendations_graph_controller.rb
@@ -24,12 +24,16 @@ class Api::V2::FollowRecommendationsGraphController < Api::BaseController
   private
 
   # return account if local user
-  # return 404 if not a local user
+  # return 404 if not a local user or personalized
   def set_account
     username, domain = username_and_domain(params[:acct])
-    return not_found unless TagManager.instance.local_domain?(domain)
+    return not_found unless TagManager.instance.local_domain?(domain) || personalized?
 
     @account = Account.find_local(username)
+  end
+
+  def personalized?
+    PersonalForYou.new.is_personalized(params[:acct])
   end
 
   def handle_to_account_remote(handle)

--- a/app/controllers/api/v2/follow_recommendations_graph_controller.rb
+++ b/app/controllers/api/v2/follow_recommendations_graph_controller.rb
@@ -33,7 +33,7 @@ class Api::V2::FollowRecommendationsGraphController < Api::BaseController
   end
 
   def personalized?
-    PersonalForYou.new.is_personalized(params[:acct])
+    PersonalForYou.new.personalized_mammoth_user?(params[:acct])
   end
 
   def handle_to_account_remote(handle)


### PR DESCRIPTION
* updates for logic on follow suggestions
 * local Moth.Social & Personalized accounts will get Friends of Friends
   * under this scenario if the follows is 0 then they get Suggested Follows from V2
 * otherwise return 404