### PR TITLE
MAM-3095-load-test-20k-ar-reduce

### DIFF
--- a/app/lib/channel_feed_manager.rb
+++ b/app/lib/channel_feed_manager.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# V1 of adding personalize statuses to a user's For You Feed
+# Done by indiviual statuses and filtered. :foryou is the
+# Mammoth curated list
+class ChannelFeedManager
+  include Singleton
+  include Redisable
+
+  MAX_ITEMS = 1000
+
+  # Adds to Channel's Feed
+  # We zip the statuses using the id for both the score of zadd and the value
+  # Creating an array of array elements [["111296866514987736", "111296866514987736"]...
+  def batch_to_feed(channel_id, status_ids)
+    statuses = status_ids.zip(status_ids)
+
+    perform_push_to_feed(channel_id, statuses)
+  end
+
+  private
+
+  def perform_push_to_feed(channel_id, statuses)
+    channel_key = key(channel_id)
+    redis.zadd(channel_key, statuses)
+
+    # Keep the list from growning infinitely
+    trim(channel_key)
+  end
+
+  # Trim a feed to maximum size by removing older items
+  # @param [Integer] foryou_key
+  # @return [void]
+  def trim(channel_key)
+    # Remove any items past the MAX_ITEMS'th entry in our feed
+    redis.zremrangebyrank(channel_key, 0, -(MAX_ITEMS + 1))
+  end
+
+  def key(_username)
+    FeedManager.instance.key(:channel, channel_id)
+  end
+end

--- a/app/lib/channel_feed_manager.rb
+++ b/app/lib/channel_feed_manager.rb
@@ -34,8 +34,10 @@ class ChannelFeedManager
   # Return Array of Statuses [{:id:111409563649339301,:account_id:110481724616652677}...]
   def fetch_threshold_statuses(channel_id)
     channel_key = key(channel_id, true)
-
-    redis.zrange(channel_key, 0, -1).map { |s| Oj.load(s, symbol_keys: true) }
+    Rails.logger.debug { "CHANNEL KEY \n\n #{channel_key}" }
+    result = redis.zrange(channel_key, 0, -1).map { |s| Oj.load(s, symbol_keys: true) }
+    Rails.logger.debug { "THRESHOLD RESULT \n\n\n\n\n  #{result}" }
+    result
   end
 
   private

--- a/app/lib/channel_feed_manager.rb
+++ b/app/lib/channel_feed_manager.rb
@@ -23,7 +23,7 @@ class ChannelFeedManager
   # keeping both id and account_id of each status for breadcrumbs
   # we serialize it to json to store
   def batch_to_threshold(channel_id, statuses)
-    # statuses = status_ids.zip(status_ids)
+    Rails.logger.debug { "CHANNEL Statuses:: #{statues.inspect}" }
     batch_statuses = statuses.map { |s| [s[:id], s.to_json] }
 
     perform_push_to_threshold(channel_id, batch_statuses)

--- a/app/lib/channel_feed_manager.rb
+++ b/app/lib/channel_feed_manager.rb
@@ -34,10 +34,7 @@ class ChannelFeedManager
   # Return Array of Statuses [{:id:111409563649339301,:account_id:110481724616652677}...]
   def fetch_threshold_statuses(channel_id)
     channel_key = key(channel_id, true)
-    Rails.logger.debug { "CHANNEL KEY \n\n #{channel_key}" }
-    result = redis.zrange(channel_key, 0, -1).map { |s| Oj.load(s, symbol_keys: true) }
-    Rails.logger.debug { "THRESHOLD RESULT \n\n\n\n\n  #{result}" }
-    result
+    redis.zrange(channel_key, 0, -1).map { |s| Oj.load(s, symbol_keys: true) }
   end
 
   private

--- a/app/lib/channel_feed_manager.rb
+++ b/app/lib/channel_feed_manager.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-# V1 of adding personalize statuses to a user's For You Feed
-# Done by indiviual statuses and filtered. :foryou is the
-# Mammoth curated list
+# Batch and maintain 2 sources of truth
+# Statuses by id for each and every channel
+# Statuses by id for each channel, **that meets it's specific threshold**
 class ChannelFeedManager
   include Singleton
   include Redisable

--- a/app/lib/channel_feed_manager.rb
+++ b/app/lib/channel_feed_manager.rb
@@ -20,10 +20,13 @@ class ChannelFeedManager
 
   # Adds to Channels Feed, but only those filtered
   # by the channels threshold
-  def batch_to_threshold(channel_id, status_ids)
-    statuses = status_ids.zip(status_ids)
+  # keeping both id and account_id of each status for breadcrumbs
+  # we serialize it to json to store
+  def batch_to_threshold(channel_id, statuses)
+    # statuses = status_ids.zip(status_ids)
+    batch_statuses = statuses.map { |s| [s[:id], s.to_json] }
 
-    perform_push_to_threshold(channel_id, statuses)
+    perform_push_to_threshold(channel_id, batch_statuses)
   end
 
   private
@@ -40,8 +43,6 @@ class ChannelFeedManager
 
   # Do the acutal adding to redis
   def push(channel_key, statuses)
-    Rails.logger.debug { "PUSH TO REDIS: #{channel_key}" }
-    Rails.logger.debug { "PUSH TO REDIS: #{statuses.inspect}" }
     redis.zadd(channel_key, statuses)
     # Keep the list from growning infinitely
     trim(channel_key)

--- a/app/lib/channel_feed_manager.rb
+++ b/app/lib/channel_feed_manager.rb
@@ -40,6 +40,8 @@ class ChannelFeedManager
 
   # Do the acutal adding to redis
   def push(channel_key, statuses)
+    Rails.logger.debug { "PUSH TO REDIS: #{channel_key}" }
+    Rails.logger.debug { "PUSH TO REDIS: #{statuses.inspect}" }
     redis.zadd(channel_key, statuses)
     # Keep the list from growning infinitely
     trim(channel_key)

--- a/app/lib/channel_feed_manager.rb
+++ b/app/lib/channel_feed_manager.rb
@@ -22,12 +22,20 @@ class ChannelFeedManager
   # by the channels threshold
   # keeping both id and account_id of each status for breadcrumbs
   # we serialize it to json to store
+  # Creating an array of array elements [["111296866514987736", "{"id":111409563649339301,"account_id":110481724616652677}"]...
   def batch_to_threshold(channel_id, statuses)
-    Rails.logger.debug { "CHANNEL Statuses:: #{statuses.inspect}" }
-    batch_statuses = statuses.map { |s| [s[:id], s.to_json] }
+    batch_statuses = statuses.map { |s| [s[:id], Oj.dump(s)] }
 
-    Rails.logger.debug { "CHANNEL Statuses:: #{batch_statuses.inspect}" }
     perform_push_to_threshold(channel_id, batch_statuses)
+  end
+
+  # Get statuses filtered by threshold
+  # Serialize json string to hash
+  # Return Array of Statuses [{:id:111409563649339301,:account_id:110481724616652677}...]
+  def fetch_threshold_statuses(channel_id)
+    channel_key = key(channel_id, true)
+
+    redis.zrange(channel_key, 0, -1).map { |s| Oj.load(s, symbol_keys: true) }
   end
 
   private

--- a/app/lib/channel_feed_manager.rb
+++ b/app/lib/channel_feed_manager.rb
@@ -23,9 +23,10 @@ class ChannelFeedManager
   # keeping both id and account_id of each status for breadcrumbs
   # we serialize it to json to store
   def batch_to_threshold(channel_id, statuses)
-    Rails.logger.debug { "CHANNEL Statuses:: #{statues.inspect}" }
+    Rails.logger.debug { "CHANNEL Statuses:: #{statuses.inspect}" }
     batch_statuses = statuses.map { |s| [s[:id], s.to_json] }
 
+    Rails.logger.debug { "CHANNEL Statuses:: #{batch_statuses.inspect}" }
     perform_push_to_threshold(channel_id, batch_statuses)
   end
 

--- a/app/lib/mammoth/channels.rb
+++ b/app/lib/mammoth/channels.rb
@@ -20,15 +20,15 @@ module Mammoth
 
     # Used in ForYou Feed
     # Get Statuses from array of channels
-    # filter out based on per channel threshold
     # User is passed all the way down to be able
     # to add specific origin per user, per channel for a status.
+    # Get all Statuses from channel_feed_manager matching channel_id
+    # Array of statuses [{"id":111409563649339301,"account_id":110481724616652677}...]
     def select_channels_with_statuses(channels, user)
       origin = Mammoth::StatusOrigin.instance
+      channel_feed_manager = ChannelFeedManager.instance
       channels.flat_map do |channel|
-        account_ids = account_ids(channel[:accounts])
-        statuses_with_accounts_from_channels(account_ids).filter_map { |s| engagment_threshold(s, channel[:fy_engagement_threshold]) }
-                                                         .each { |s| origin.add_channel(s, user, channel) }
+        channel_feed_manager.fetch_threshold_statuses(channel[:id]).each { |s| origin.add_channel(s, user, channel) }
       end
     end
 

--- a/app/lib/mammoth/channels.rb
+++ b/app/lib/mammoth/channels.rb
@@ -74,7 +74,7 @@ module Mammoth
     # Channel includes id, title, description, owner
     def list(include_accounts: false)
       cache_key = include_accounts ? 'channels:list:w_accounts' : 'channels:list'
-      Rails.cache.fetch(cache_key, expires_in: 60.seconds) do
+      Rails.cache.fetch(cache_key, expires_in: 1.day) do
         response = HTTP.headers({ Authorization: ACCOUNT_RELAY_AUTH, 'Content-Type': 'application/json' }).get(
           "https://#{ACCOUNT_RELAY_HOST}/api/v1/channels?include_accounts=#{include_accounts}"
         )
@@ -85,7 +85,7 @@ module Mammoth
     # GET channel by id and return all details
     def find(id)
       cache_key = "channels:list:#{id}"
-      Rails.cache.fetch(cache_key, expires_in: 60.seconds) do
+      Rails.cache.fetch(cache_key, expires_in: 1.day) do
         response = HTTP.headers({ Authorization: ACCOUNT_RELAY_AUTH, 'Content-Type': 'application/json' }).get(
           "https://#{ACCOUNT_RELAY_HOST}/api/v1/channels/#{id}"
         )

--- a/app/lib/mammoth/channels.rb
+++ b/app/lib/mammoth/channels.rb
@@ -36,8 +36,8 @@ module Mammoth
     # Ensure we are checking statues as far back at 48 hours
     def filter_statuses_with_threshold
       channels_with_statuses.map do |channel|
-        account_ids = account_ids(channel[:accounts])
-        statuses_with_accounts_from_channels(account_ids).filter_map { |s| engagment_threshold(s, channel[:fy_engagement_threshold]) }
+        channel[:statuses] = channel[:statuses].filter_map { |s| engagment_threshold(s, channel[:fy_engagement_threshold]) }
+        channel
       end
     end
 

--- a/app/lib/mammoth/channels.rb
+++ b/app/lib/mammoth/channels.rb
@@ -46,12 +46,6 @@ module Mammoth
                    created_at: (GO_BACK.hours.ago)..Time.current)
     end
 
-    # Not entirely sure why we're including `:account`
-    def statuses_with_accounts_from_channels(account_ids)
-      Status.includes([:account]).where(account_id: account_ids,
-                                        created_at: (GO_BACK.hours.ago)..Time.current)
-    end
-
     # Check status for Channel's set level of engagment
     # Filter out polls and replys
     def engagment_threshold(wrapped_status, channel_engagment_setting)
@@ -74,7 +68,7 @@ module Mammoth
     # Channel includes id, title, description, owner
     def list(include_accounts: false)
       cache_key = include_accounts ? 'channels:list:w_accounts' : 'channels:list'
-      Rails.cache.fetch(cache_key, expires_in: 1.day) do
+      Rails.cache.fetch(cache_key, expires_in: 1.hour) do
         response = HTTP.headers({ Authorization: ACCOUNT_RELAY_AUTH, 'Content-Type': 'application/json' }).get(
           "https://#{ACCOUNT_RELAY_HOST}/api/v1/channels?include_accounts=#{include_accounts}"
         )
@@ -85,7 +79,7 @@ module Mammoth
     # GET channel by id and return all details
     def find(id)
       cache_key = "channels:list:#{id}"
-      Rails.cache.fetch(cache_key, expires_in: 1.day) do
+      Rails.cache.fetch(cache_key, expires_in: 1.hour) do
         response = HTTP.headers({ Authorization: ACCOUNT_RELAY_AUTH, 'Content-Type': 'application/json' }).get(
           "https://#{ACCOUNT_RELAY_HOST}/api/v1/channels/#{id}"
         )

--- a/app/lib/mammoth/curated_list.rb
+++ b/app/lib/mammoth/curated_list.rb
@@ -14,6 +14,10 @@ module Mammoth
       statuses_from_list(account_ids)
     end
 
+    # Get Statuses from Mammoth Pick's list
+    # Filter using engagment threshold
+    # only return id and account_id for breadcrumbs
+    # This is constantly updating, cache for only a couple minutes
     def statuses_from_list(account_ids)
       cache_key = 'mammoth_picks:statuses'
       Rails.cache.fetch(cache_key, expires_in: 120.seconds) do
@@ -24,6 +28,8 @@ module Mammoth
       end
     end
 
+    # Accounts on the Mammoth Pick's List
+    # These are rarely chanaged
     def mammoth_curated_accounts
       cache_key = 'mammoth_picks:accounts'
       Rails.cache.fetch(cache_key, expires_in: 1.day) do
@@ -35,7 +41,7 @@ module Mammoth
 
     private
 
-    # Check status for User's level of engagment
+    # Check status for Set Engagment
     # Filter out polls and replys
     def engagment_threshold(wrapped_status)
       # enagagment threshold

--- a/app/lib/mammoth/curated_list.rb
+++ b/app/lib/mammoth/curated_list.rb
@@ -20,7 +20,7 @@ module Mammoth
         statuses = Status.where(account_id: account_ids,
                                 created_at: (GO_BACK.hours.ago)..Time.current).to_a
 
-        statuses.filter_map(&:engagment_threshold).pluck(:id, :account_id).map { |id, account_id| { id: id, account_id: account_id } }
+        statuses.filter_map { |s| engagment_threshold(s) }.pluck(:id, :account_id).map { |id, account_id| { id: id, account_id: account_id } }
       end
     end
 

--- a/app/lib/mammoth/curated_list.rb
+++ b/app/lib/mammoth/curated_list.rb
@@ -9,10 +9,7 @@ module Mammoth
     LIST_TITLE = 'For You'
 
     def curated_list_statuses
-      cache_key = 'mammoth_picks:accounts'
-      account_ids = Rails.cache.fetch(cache_key, expires_in: 1.day) do
-        mammoth_curated_accounts
-      end
+      account_ids = mammoth_curated_accounts
       statuses_from_list(account_ids)
     end
 
@@ -20,14 +17,17 @@ module Mammoth
       cache_key = 'mammoth_picks:statuses'
       Rails.cache.fetch(cache_key, expires_in: 60.seconds) do
         Status.where(account_id: account_ids,
-                     created_at: (GO_BACK.hours.ago)..Time.current)
+                     created_at: (GO_BACK.hours.ago)..Time.current).to_a
       end
     end
 
     def mammoth_curated_accounts
-      owner_account = Account.local.where(username: FOR_YOU_OWNER_ACCOUNT)
-      @list = List.where(account: owner_account, title: LIST_TITLE).first!
-      @list.list_accounts.pluck(:account_id)
+      cache_key = 'mammoth_picks:accounts'
+      Rails.cache.fetch(cache_key, expires_in: 1.day) do
+        owner_account = Account.local.where(username: FOR_YOU_OWNER_ACCOUNT)
+        @list = List.where(account: owner_account, title: LIST_TITLE).first!
+        @list.list_accounts.pluck(:account_id).to_a
+      end
     end
   end
 end

--- a/app/lib/mammoth/curated_list.rb
+++ b/app/lib/mammoth/curated_list.rb
@@ -9,19 +9,25 @@ module Mammoth
     LIST_TITLE = 'For You'
 
     def curated_list_statuses
-      account_ids = mammoth_curated_accounts
+      cache_key = 'mammoth_picks:accounts'
+      account_ids = Rails.cache.fetch(cache_key, expires_in: 1.day) do
+        mammoth_curated_accounts
+      end
       statuses_from_list(account_ids)
+    end
+
+    def statuses_from_list(account_ids)
+      cache_key = 'mammoth_picks:statuses'
+      Rails.cache.fetch(cache_key, expires_in: 60.seconds) do
+        Status.where(account_id: account_ids,
+                     created_at: (GO_BACK.hours.ago)..Time.current)
+      end
     end
 
     def mammoth_curated_accounts
       owner_account = Account.local.where(username: FOR_YOU_OWNER_ACCOUNT)
       @list = List.where(account: owner_account, title: LIST_TITLE).first!
       @list.list_accounts.pluck(:account_id)
-    end
-
-    def statuses_from_list(account_ids)
-      Status.where(account_id: account_ids,
-                   created_at: (GO_BACK.hours.ago)..Time.current)
     end
   end
 end

--- a/app/lib/mammoth/status_origin.rb
+++ b/app/lib/mammoth/status_origin.rb
@@ -27,7 +27,6 @@ module Mammoth
 
     # Add Status and Reason to list
     def add_channel(status, user, channel)
-        Rails.logger.debug "ADD CHANNEL REASON \n\n\n #{status}  #{channel.inspect}"
         list_key = key(user[:acct], status[:id])
         reason = channel_reason(status, channel)
         
@@ -87,7 +86,6 @@ module Mammoth
     end
 
     def channel_reason(status, channel)
-        Rails.logger.debug "CHANNEL REASON \n\n\n #{status}"
         Oj.dump({source: "SmartList", channel_id: channel[:id], title: channel[:title], originating_account_id: status[:account_id]})
     end
 

--- a/app/lib/mammoth/status_origin.rb
+++ b/app/lib/mammoth/status_origin.rb
@@ -86,7 +86,7 @@ module Mammoth
     end
 
     def channel_reason(status, channel)
-        Oj.dump({source: "SmartList", channel_id: channel[:id], title: channel[:title], originating_account_id: status.account[:id]})
+        Oj.dump({source: "SmartList", channel_id: channel[:id], title: channel[:title], originating_account_id: status[:account_id]})
     end
 
     def mammoth_pick_reason(status)

--- a/app/lib/mammoth/status_origin.rb
+++ b/app/lib/mammoth/status_origin.rb
@@ -90,7 +90,7 @@ module Mammoth
     end
 
     def mammoth_pick_reason(status)
-        Oj.dump({source: "MammothPick", originating_account_id: status.account[:id] })
+        Oj.dump({source: "MammothPick", originating_account_id: status[:account_id] })
     end
 
     def trending_follow_reason(status)

--- a/app/lib/mammoth/status_origin.rb
+++ b/app/lib/mammoth/status_origin.rb
@@ -27,6 +27,7 @@ module Mammoth
 
     # Add Status and Reason to list
     def add_channel(status, user, channel)
+        Rails.logger.debug "ADD CHANNEL REASON \n\n\n #{status}  #{channel.inspect}"
         list_key = key(user[:acct], status[:id])
         reason = channel_reason(status, channel)
         
@@ -86,6 +87,7 @@ module Mammoth
     end
 
     def channel_reason(status, channel)
+        Rails.logger.debug "CHANNEL REASON \n\n\n #{status}"
         Oj.dump({source: "SmartList", channel_id: channel[:id], title: channel[:title], originating_account_id: status[:account_id]})
     end
 

--- a/app/workers/scheduler/channel_mammoth_statuses_scheduler.rb
+++ b/app/workers/scheduler/channel_mammoth_statuses_scheduler.rb
@@ -38,6 +38,13 @@ class Scheduler::ChannelMammothStatusesScheduler
     end
   end
 
+  def channel_status_account_ids(channel)
+    {
+      id: channel[:id],
+      statuses: channel[:statuses].pluck(:id, :account_id).map { |id, account_id| { id: id, account_id: account_id } },
+    }
+  end
+
   def channel_feed_manager
     ChannelFeedManager.instance
   end

--- a/app/workers/scheduler/channel_mammoth_statuses_scheduler.rb
+++ b/app/workers/scheduler/channel_mammoth_statuses_scheduler.rb
@@ -34,7 +34,7 @@ class Scheduler::ChannelMammothStatusesScheduler
     filtered_channels = Mammoth::Channels.new.filter_statuses_with_threshold
     filtered_channels.each do |channel|
       Rails.logger.debug { "FILTER CHANNEL::  #{channel} \n" }
-      channel_feed_manager.batch_to_threshold(channel[:id], channel[:statuses].pluck('id'))
+      channel_feed_manager.batch_to_threshold(channel[:id], channel[:statuses].pluck(:id, :account_id))
     end
   end
 

--- a/app/workers/scheduler/channel_mammoth_statuses_scheduler.rb
+++ b/app/workers/scheduler/channel_mammoth_statuses_scheduler.rb
@@ -26,7 +26,7 @@ class Scheduler::ChannelMammothStatusesScheduler
     channels = Mammoth::Channels.new.channels_with_statuses
     channels.each do |channel|
       Rails.logger.debug { "CHANNEL::  #{channel} \n" }
-      channel_feed_manager.batch_to_feed(channel[:id], channel[:statuses])
+      channel_feed_manager.batch_to_feed(channel[:id], channel[:statuses].pluck('id'))
     end
   end
 
@@ -34,7 +34,7 @@ class Scheduler::ChannelMammothStatusesScheduler
     filtered_channels = Mammoth::Channels.new.filter_statuses_with_threshold
     filtered_channels.each do |channel|
       Rails.logger.debug { "FILTER CHANNEL::  #{channel} \n" }
-      channel_feed_manager.batch_to_threshold(channel[:id], channel[:statuses])
+      channel_feed_manager.batch_to_threshold(channel[:id], channel[:statuses].pluck('id'))
     end
   end
 

--- a/app/workers/scheduler/channel_mammoth_statuses_scheduler.rb
+++ b/app/workers/scheduler/channel_mammoth_statuses_scheduler.rb
@@ -26,16 +26,11 @@ class Scheduler::ChannelMammothStatusesScheduler
   def update_channel_feeds!
     @channels.each do |channel|
       Rails.logger.debug { "CHANNEL::  #{channel} \n" }
-      channel_feed_manager.batch_to_feed(channle[:id], channel[:statuses])
+      channel_feed_manager.batch_to_feed(channel[:id], channel[:statuses])
     end
   end
 
   def channel_feed_manager
     ChannelFeedManager.instance
-  end
-
-  # Filter statuses based on engagment and push to feed.
-  def push_statuses(statuses, channel_id)
-    statuses.each { |status| ChannelFeedWorker.perform_async(status['id'], channel_id) }
   end
 end

--- a/app/workers/scheduler/channel_mammoth_statuses_scheduler.rb
+++ b/app/workers/scheduler/channel_mammoth_statuses_scheduler.rb
@@ -34,7 +34,7 @@ class Scheduler::ChannelMammothStatusesScheduler
     filtered_channels = Mammoth::Channels.new.filter_statuses_with_threshold
     filtered_channels.each do |channel|
       Rails.logger.debug { "FILTER CHANNEL::  #{channel} \n" }
-      channel_feed_manager.batch_to_threshold(channel[:id], channel[:statuses].pluck(:id, :account_id))
+      channel_feed_manager.batch_to_threshold(channel[:id], channel[:statuses].pluck(:id, :account_id).map { |id, account_id| { id: id, account_id: account_id } })
     end
   end
 

--- a/app/workers/update_for_you_worker.rb
+++ b/app/workers/update_for_you_worker.rb
@@ -102,10 +102,9 @@ class UpdateForYouWorker
     list_statuses = curated_list.curated_list_statuses
     origin = Mammoth::StatusOrigin.instance
 
-    list_statuses.filter_map { |s| engagment_threshold(s, user_setting[:curated_by_mammoth], 'mammoth') }
-                 .map do |s|
+    list_statuses.map do |s|
       origin.add_mammoth_pick(s, @user)
-      s['id']
+      s[:id]
     end
   end
 

--- a/app/workers/update_for_you_worker.rb
+++ b/app/workers/update_for_you_worker.rb
@@ -90,7 +90,7 @@ class UpdateForYouWorker
     user_setting = @user[:for_you_settings]
     return if user_setting[:from_your_channels].zero?
 
-    @personal.statuses_for_enabled_channels(@user).pluck('id')
+    @personal.statuses_for_enabled_channels(@user).pluck(:id)
   end
 
   # Mammoth Curated OG List


### PR DESCRIPTION
* reduce / eliminate UpdateForYou from making repeated active record calls. grouping them once by the already running channel update worker and using those.

![Safari 2023-11-15 at 11 43 22@2x](https://github.com/TheBLVD/moth.social/assets/76360/cf62239a-50b4-47ff-b770-e9a5eb36810b)
![Safari 2023-11-15 at 11 44 22@2x](https://github.com/TheBLVD/moth.social/assets/76360/8ae21bad-a942-4124-bf6e-be496a759849)
