### PR TITLE
MAM-3238-on-refresh-of-foryou-feed-not-clearing-old-posts

### DIFF
--- a/app/controllers/api/v3/timelines/for_you_controller.rb
+++ b/app/controllers/api/v3/timelines/for_you_controller.rb
@@ -4,8 +4,11 @@ class Api::V3::Timelines::ForYouController < Api::BaseController
   # TODO: Re-enable with fix
   # before_action :require_mammoth!
   before_action :set_for_you_default, only: [:show]
-
   after_action :insert_pagination_headers, only: [:show], unless: -> { @statuses.empty? }
+
+  rescue_from PersonalForYou::Error do |exception|
+    render json: { error: exception }, status: 404
+  end
 
   def index
     result = PersonalForYou.new.mammoth_user_profile(acct_param)

--- a/app/controllers/api/v3/timelines/for_you_controller.rb
+++ b/app/controllers/api/v3/timelines/for_you_controller.rb
@@ -75,16 +75,10 @@ class Api::V3::Timelines::ForYouController < Api::BaseController
     for_you.add_to_enrollment(acct_param)
   end
 
-  # Will not return an empty list
-  # If no statuses are found for the user,
-  # but they are on the beta list then we return the default Public Feed
+  # Determined to be a Mammoth 2.0 user
+  # Return Personalized ForYou Feed
   def fufill_foryou_statuses
-    statuses = cached_personalized_statuses
-    if statuses.empty?
-      cached_list_statuses
-    else
-      statuses
-    end
+    cached_personalized_statuses
   end
 
   def cached_personalized_statuses

--- a/app/controllers/api/v3/timelines/for_you_controller.rb
+++ b/app/controllers/api/v3/timelines/for_you_controller.rb
@@ -8,7 +8,7 @@ class Api::V3::Timelines::ForYouController < Api::BaseController
   after_action :insert_pagination_headers, only: [:show], unless: -> { @statuses.empty? }
 
   def index
-    result = PersonalForYou.new.mammoth_user(acct_param)
+    result = PersonalForYou.new.mammoth_user_profile(acct_param)
     render json: result
   end
 
@@ -40,11 +40,14 @@ class Api::V3::Timelines::ForYouController < Api::BaseController
     @is_beta_program = beta_param
   end
 
+  # Check and see if they're a Mammoth User
+  # If they are get their foryou feed
+  # Otherwise send them MammothPicks
   def set_for_you_feed
     should_personalize = validate_mammoth_account
     if should_personalize
       # Getting personalized
-      fufill_personalized_statuses
+      fufill_foryou_statuses
     else
       # Getting the public feed
       enroll_beta
@@ -53,12 +56,12 @@ class Api::V3::Timelines::ForYouController < Api::BaseController
   end
 
   # Check account_from_acct finds an account
-  # Check the For You Beta Personal List
+  # Check AccountRelay that they are a Mammoth 2.0 User
   # @return [Boolean]
   def validate_mammoth_account
     return false if @account.nil?
 
-    PersonalForYou.new.personalized_mammoth_user?(acct_param)
+    PersonalForYou.new.mammoth_user?(acct_param)
   end
 
   # Only checking for beta parameter
@@ -75,7 +78,7 @@ class Api::V3::Timelines::ForYouController < Api::BaseController
   # Will not return an empty list
   # If no statuses are found for the user,
   # but they are on the beta list then we return the default Public Feed
-  def fufill_personalized_statuses
+  def fufill_foryou_statuses
     statuses = cached_personalized_statuses
     if statuses.empty?
       cached_list_statuses

--- a/app/lib/personal_for_you.rb
+++ b/app/lib/personal_for_you.rb
@@ -83,7 +83,7 @@ class PersonalForYou
     response = HTTP.headers({ Authorization: ACCOUNT_RELAY_AUTH, 'Content-Type': 'application/json' }).get(
       "https://#{ACCOUNT_RELAY_HOST}/api/v1/foryou/users/#{acct}"
     )
-    raise PersonalForYou::Error, "Request for #{acct} returned HTTP #{res.code}" unless res.code == 200
+    raise PersonalForYou::Error, "Request for #{acct} returned HTTP #{response.code}" unless response.code == 200
 
     JSON.parse(response.body, symbolize_names: true)
   end

--- a/app/lib/personal_for_you.rb
+++ b/app/lib/personal_for_you.rb
@@ -55,7 +55,7 @@ class PersonalForYou
   # If the for_you setting is public, get waitlist feature
   # and check for enrollment.
   # for_you_setting type can be 'public' | 'personal' | 'waitlist'
-  def mammoth_user(acct)
+  def mammoth_user_profile(acct)
     user = user(acct)
     return user unless user[:for_you_settings][:type] == 'public'
 
@@ -63,6 +63,15 @@ class PersonalForYou
     waitlist = waitlist_status(acct)
     user[:for_you_settings][:type] = 'waitlist' if waitlist == 'enrolled'
     user
+  end
+
+  # Check AcctRelay if the user is a Mammoth User
+  # Could be personalized or not. either way.
+  def fetch_mammoth_user?(acct)
+    response = HTTP.headers({ Authorization: ACCOUNT_RELAY_AUTH, 'Content-Type': 'application/json' }).get(
+      "https://#{ACCOUNT_RELAY_HOST}/api/v1/foryou/users/#{acct}/mammoth"
+    )
+    JSON.parse(response.body, symbolize_names: true)
   end
 
   # Get Mammoth user details
@@ -89,6 +98,10 @@ class PersonalForYou
   # The default foryou settings type is 'public
   def personalized_mammoth_user?(acct)
     user(acct).dig(:for_you_settings, :type) == 'personal'
+  end
+
+  def mammoth_user?(acct)
+    fetch_mammoth_user?(acct)[:mammoth_user]
   end
 
   # PUT Mammoth user for you settings / preferences / status

--- a/app/lib/personal_for_you.rb
+++ b/app/lib/personal_for_you.rb
@@ -5,8 +5,9 @@ class PersonalForYou
 
   ACCOUNT_RELAY_AUTH = "Bearer #{ENV.fetch('ACCOUNT_RELAY_KEY')}".freeze
   ACCOUNT_RELAY_HOST = 'acctrelay.moth.social'
-
   FEATURE_HOST = 'feature.moth.social'
+
+  class Error < StandardError; end
 
   # Cache Key for User
   def key(acct)
@@ -46,8 +47,9 @@ class PersonalForYou
     response = HTTP.headers({ Authorization: ACCOUNT_RELAY_AUTH, 'Content-Type': 'application/json' }).get(
       "https://#{ACCOUNT_RELAY_HOST}/api/v1/foryou/users"
     )
-    results = JSON.parse(response.body).map(&:symbolize_keys).pluck(:acct)
-    results unless response.code != 200
+    raise PersonalForYou::Error, "Request for users returned HTTP #{res.code}" unless res.code == 200
+
+    JSON.parse(response.body).map(&:symbolize_keys).pluck(:acct)
   end
 
   # Aggregate mammoth user from AcctRelay with Feature Api
@@ -81,6 +83,8 @@ class PersonalForYou
     response = HTTP.headers({ Authorization: ACCOUNT_RELAY_AUTH, 'Content-Type': 'application/json' }).get(
       "https://#{ACCOUNT_RELAY_HOST}/api/v1/foryou/users/#{acct}"
     )
+    raise PersonalForYou::Error, "Request for #{acct} returned HTTP #{res.code}" unless res.code == 200
+
     JSON.parse(response.body, symbolize_names: true)
   end
 


### PR DESCRIPTION
* Remove condițional check to return 'Mammoth Picks' when the user's ForYou returns zero.
  * This can happen during pagination, it will eventually return 0 [Zero] and then start sending 'Mammoth Picks'
 * Couple http error catches 