### PR TITLE
 MAM-3276-foryou-logging-mammoth-10-users-as-new-20-users

### DIFF
--- a/app/controllers/api/v4/timelines/for_you_controller.rb
+++ b/app/controllers/api/v4/timelines/for_you_controller.rb
@@ -47,9 +47,10 @@ class Api::V4::Timelines::ForYouController < Api::BaseController
     @user = user_from_param
   end
 
-  # Check and see if they're a Mammoth User
+  # Check user is personalzied
   # If they are get their foryou feed
   # Otherwise send them MammothPicks
+  # TODO: overload foryou tasks, fallback to MammothPicks here.
   def set_for_you_feed
     if personalized_feed?
       # Getting personalized

--- a/app/controllers/api/v4/timelines/statuses_controller.rb
+++ b/app/controllers/api/v4/timelines/statuses_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Api::V4::Timelines::StatusesController < Api::BaseController
+  before_action :require_mammoth!
+
+  rescue_from Mammoth::StatusOrigin::NotFound do |e|
+    # Report error
+    user_account = @decoded['sub']
+    Appsignal.send_error(e) do |transaction|
+      transaction.set_action('foryou')
+      transaction.set_namespace('for_you')
+      transaction.params = { time: Time.now.utc, status_id: status_id_param, user_account: user_account }
+    end
+    render json: { error: e.to_s }, status: 404
+  end
+
+  def show
+    origin = Mammoth::StatusOrigin.instance
+    user_account = @decoded['sub']
+    Rails.logger.debug { "ACCT: #{user_account}" }
+    @origins = origin.find(status_id_param, user_account)
+    render json: @origins, each_serializer: StatusOriginSerializer
+  end
+
+  private
+
+  def status_id_param
+    params.require(:id)
+  end
+end

--- a/app/models/for_you_feed.rb
+++ b/app/models/for_you_feed.rb
@@ -3,11 +3,19 @@
 class ForYouFeed < Feed
   def initialize(type = 'personal', id)
     @type = type.to_sym
+    @id = id
+
     case @type
     when :personal
       super(:personal, id)
     when :foryou
       super(:foryou, id)
     end
+  end
+
+  # If there is an foryou feed
+  # redis returns 1 for true, 0 for false
+  def exists?
+    redis.exists(@id) == 1
   end
 end

--- a/app/models/for_you_feed.rb
+++ b/app/models/for_you_feed.rb
@@ -16,6 +16,10 @@ class ForYouFeed < Feed
   # If there is an foryou feed
   # redis returns 1 for true, 0 for false
   def exists?
-    redis.exists(@id) == 1
+    redis.exists(key) == 1
+  end
+
+  def key
+    FeedManager.instance.key(@type, @id)
   end
 end

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -332,6 +332,15 @@ namespace :api, format: false do
     end
   end
 
+  namespace :v4 do
+    namespace :timelines do
+      resource :for_you, only: [:show], controller: 'for_you' do
+        get '/me',      to: 'for_you#index'
+        put '/me',      to: 'for_you#update'
+      end
+    end
+  end
+
   # Web
   namespace :web do
     resource :settings, only: [:update]

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -335,6 +335,7 @@ namespace :api, format: false do
   namespace :v4 do
     namespace :timelines do
       resource :for_you, only: [:show], controller: 'for_you' do
+        resources :statuses, only: :show, controller: :statuses
         get '/me',      to: 'for_you#index'
         put '/me',      to: 'for_you#update'
       end


### PR DESCRIPTION
* Versions for you timeline feed and logic to v4. Splitting out the current v3 that serves mammoth 1.0 users. 
  * V4 doesn't have to validate you're a mammoth 1 or 2 user
  * Still falls back to mammoth picks, but only if you have no generated for you feed
  * Not effected by paginating to end of statuses, and then falling through to mammoth picks.
  * Once deployed simplify V3 to only serve Mammoth Picks


See release steps: https://linear.app/theblvd/issue/MAM-3276/foryou-logging-mammoth-10-users-as-new-20-users-🤦‍♂️#comment-72d0d79b