### PR TITLE
 MAM-3304-big-red-button

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -80,11 +80,18 @@ SESSION_RETENTION_PERIOD=31556952
 FOR_YOU_OWNER_ACCOUNT=admin
 
 # Token Authorization Key for AccountRelay Server
+# Required
 ACCOUNT_RELAY_KEY=xxxxxx
 
 
 # JWT Decode MAMMOTH AUTHENTICATION
+# Required
 MAMMOTH_SECRET_KEY=xxxxxx
 
 # Multiple number of users to load test the ForYouMammothFeed Scheduler
+# Optional
 FOR_YOU_LOAD_TEST_MULTIPLIER=1
+
+# Overload backpressure release value
+# Optional
+MAMMOTH_OVERLOAD_ENABLE=false

--- a/app/controllers/api/v3/timelines/for_you_controller.rb
+++ b/app/controllers/api/v3/timelines/for_you_controller.rb
@@ -32,6 +32,11 @@ class Api::V3::Timelines::ForYouController < Api::BaseController
     )
   end
 
+  # Mammoth Picks list
+  def default_list
+    List.where(account: @default_owner_account, title: LIST_TITLE).first!
+  end
+
   def list_feed
     ForYouFeed.new('foryou', default_list.id)
   end

--- a/app/controllers/api/v3/timelines/for_you_controller.rb
+++ b/app/controllers/api/v3/timelines/for_you_controller.rb
@@ -7,7 +7,7 @@ class Api::V3::Timelines::ForYouController < Api::BaseController
   after_action :insert_pagination_headers, only: [:show], unless: -> { @statuses.empty? }
 
   def show
-    @statuses = cached_personalized_statuses
+    @statuses = list_statuses
     render json: @statuses,
            each_serializer: REST::StatusSerializer
   end
@@ -19,7 +19,7 @@ class Api::V3::Timelines::ForYouController < Api::BaseController
     @account = account_from_acct
   end
 
-  def cached_list_statuses
+  def list_statuses
     cache_collection general_for_you_list_statuses, Status
   end
 

--- a/app/controllers/api/v3/timelines/for_you_controller.rb
+++ b/app/controllers/api/v3/timelines/for_you_controller.rb
@@ -6,32 +6,10 @@ class Api::V3::Timelines::ForYouController < Api::BaseController
   before_action :set_for_you_default, only: [:show]
   after_action :insert_pagination_headers, only: [:show], unless: -> { @statuses.empty? }
 
-  rescue_from PersonalForYou::Error do |exception|
-    render json: { error: exception }, status: 404
-  end
-
-  def index
-    result = PersonalForYou.new.mammoth_user_profile(acct_param)
-    render json: result
-  end
-
   def show
-    @statuses = set_for_you_feed
+    @statuses = cached_personalized_statuses
     render json: @statuses,
            each_serializer: REST::StatusSerializer
-  end
-
-  # When Updating User with new settings
-  # Update status to 'pending'
-  # Also need to trigger a clear & rebuild of their personal for you feed
-  def update
-    payload = for_you_params
-    payload[:status] = 'pending'
-    result = PersonalForYou.new.update_user(acct_param, payload)
-
-    # Set Queue specificly for a rebuild
-    UpdateForYouWorker.set(queue: 'mammoth_critial').perform_async({ acct: acct_param, rebuild: true })
-    render json: result
   end
 
   private
@@ -39,60 +17,6 @@ class Api::V3::Timelines::ForYouController < Api::BaseController
   def set_for_you_default
     @default_owner_account = Account.local.where(username: FOR_YOU_OWNER_ACCOUNT).first!
     @account = account_from_acct
-    @user = user_from_param
-    @is_beta_program = beta_param
-  end
-
-  # Check and see if they're a Mammoth User
-  # If they are get their foryou feed
-  # Otherwise send them MammothPicks
-  def set_for_you_feed
-    should_personalize = validate_mammoth_account
-    if should_personalize
-      # Getting personalized
-      fufill_foryou_statuses
-    else
-      # Getting the public feed
-      enroll_beta
-      cached_list_statuses
-    end
-  end
-
-  # Check account_from_acct finds an account
-  # Check AccountRelay that they are a Mammoth 2.0 User
-  # @return [Boolean]
-  def validate_mammoth_account
-    return false if @account.nil?
-
-    PersonalForYou.new.mammoth_user?(acct_param)
-  end
-
-  # Only checking for beta parameter
-  # After we've validated the acct is NOT on the beta list
-  # So if you're already on the beta list we're not going add them
-  def enroll_beta
-    return unless @is_beta_program
-
-    # Add to beta enrollment list
-    for_you = ForYouBeta.new
-    for_you.add_to_enrollment(acct_param)
-  end
-
-  # Determined to be a Mammoth 2.0 user
-  # Return Personalized ForYou Feed
-  # TODO: Revert once v4 is out for testflight users
-  # Always return Mammoth Picks at that point
-  def fufill_foryou_statuses
-    statuses = cached_personalized_statuses
-    if statuses.empty?
-      cached_list_statuses
-    else
-      statuses
-    end
-  end
-
-  def cached_personalized_statuses
-    cache_collection personalized_for_you_list_statuses, Status
   end
 
   def cached_list_statuses
@@ -108,23 +32,6 @@ class Api::V3::Timelines::ForYouController < Api::BaseController
     )
   end
 
-  def personalized_for_you_list_statuses
-    personalzied_feed.get(
-      limit_param(DEFAULT_STATUSES_LIST_LIMIT),
-      params[:max_id],
-      params[:since_id],
-      params[:min_id]
-    )
-  end
-
-  def personalzied_feed
-    ForYouFeed.new('personal', @user[:acct])
-  end
-
-  def default_list
-    List.where(account: @default_owner_account, title: LIST_TITLE).first!
-  end
-
   def list_feed
     ForYouFeed.new('foryou', default_list.id)
   end
@@ -138,31 +45,8 @@ class Api::V3::Timelines::ForYouController < Api::BaseController
     Account.where(username: username, domain: domain).first
   end
 
-  def user_from_param
-    PersonalForYou.new.user(acct_param)
-  end
-
   def acct_param
     params.require(:acct)
-  end
-
-  def for_you_params
-    params.permit(
-      :acct,
-      [enabled_channels: []],
-      :curated_by_mammoth,
-      :friends_of_friends,
-      :from_your_channels,
-      :your_follows
-    ).except('acct')
-  end
-
-  # Used to indicate beta group
-  # for testflight
-  def beta_param
-    return if params[:beta].nil?
-
-    params[:beta].casecmp('true').zero?
   end
 
   # Pagination

--- a/app/controllers/api/v4/timelines/for_you_controller.rb
+++ b/app/controllers/api/v4/timelines/for_you_controller.rb
@@ -2,8 +2,7 @@
 
 # Serving Mammoth 2.0
 class Api::V4::Timelines::ForYouController < Api::BaseController
-  # TODO: Re-enable with fix
-  # before_action :require_mammoth!
+  before_action :require_mammoth!
   before_action :set_for_you_default, only: [:show]
   after_action :insert_pagination_headers, only: [:show], unless: -> { @statuses.empty? }
 

--- a/app/controllers/api/v4/timelines/for_you_controller.rb
+++ b/app/controllers/api/v4/timelines/for_you_controller.rb
@@ -148,11 +148,11 @@ class Api::V4::Timelines::ForYouController < Api::BaseController
   end
 
   def next_path
-    api_v3_timelines_for_you_url pagination_params(max_id: pagination_max_id)
+    api_v4_timelines_for_you_url pagination_params(max_id: pagination_max_id)
   end
 
   def prev_path
-    api_v3_timelines_for_you_url pagination_params(min_id: pagination_since_id)
+    api_v4_timelines_for_you_url pagination_params(min_id: pagination_since_id)
   end
 
   def pagination_max_id

--- a/app/services/for_you_mammoth_service_check.rb
+++ b/app/services/for_you_mammoth_service_check.rb
@@ -6,8 +6,13 @@
 class ForYouMammothServiceCheck < BaseService
   class Error < StandardError; end
 
+  # Overload backpressure release value
+  MAMMOTH_OVERLOAD_ENABLE = ENV['MAMMOTH_OVERLOAD_ENABLE'] == 'true'
+  Rails.logger.warn 'ForYouMammothScheduler MAMMOTH_OVERLOAD_ENABLED' if MAMMOTH_OVERLOAD_ENABLE
+
   def call
     begin
+      mammoth_overload?
       update_worker_in_process?
     rescue Error => e
       Rails.logger.warn("error: #{e}")
@@ -18,6 +23,10 @@ class ForYouMammothServiceCheck < BaseService
       end
       raise e
     end
+  end
+
+  def mammoth_overload?
+    raise Error, 'UpdateForYouScheduler Overload Enabled' if MAMMOTH_OVERLOAD_ENABLE
   end
 
   # Check specificly for any UpdateWorker

--- a/app/workers/scheduler/for_you_mammoth_scheduler.rb
+++ b/app/workers/scheduler/for_you_mammoth_scheduler.rb
@@ -11,8 +11,8 @@ class Scheduler::ForYouMammothScheduler
 
   sidekiq_options retry: 0
 
+  # Specific to Load testing
   LOAD_TEST_MULTIPLIER = ENV['FOR_YOU_LOAD_TEST_MULTIPLIER'].to_i || 1
-
   Rails.logger.warn "ForYouMammothScheduler LOAD TEST:: x#{LOAD_TEST_MULTIPLIER}" if LOAD_TEST_MULTIPLIER > 1
 
   def perform

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -326,12 +326,11 @@ namespace :api, format: false do
       resources :channels, only: :show, controller: :channels
       resource :for_you, only: [:show], controller: 'for_you' do
         resources :statuses, only: :show, controller: :statuses
-        get '/me',      to: 'for_you#index'
-        put '/me',      to: 'for_you#update'
       end
     end
   end
 
+  # V4 Mammoth 2.0
   namespace :v4 do
     namespace :timelines do
       resource :for_you, only: [:show], controller: 'for_you' do


### PR DESCRIPTION
## Big Red Button
* Enable ForYouWorker to be skipped in the event of being overloaded. This is manually enabled/disabled
   * disables the scheduler from running mammoth user for you updates
   * returns 'overloaded' as the user's for you setting `status` 
   * `timelines/foryou/` returns cached MammothPicks with threshold enabled posts. Updated every 5 minutes.
 * Re-enabled auth calls for client jwt. [MAM-3078](https://linear.app/theblvd/issue/MAM-3078/mammoth-auth-for-endpoints-needs-to-be-re-enabled)

> [!IMPORTANT]  
> MAMMOTH_OVERLOAD_ENABLE in the .env must be set to `true` and both web & sidekiq services restarted to have any effect. 

![Firefox Developer Edition 2023-11-27 at 15 21 32@2x](https://github.com/TheBLVD/moth.social/assets/76360/073262a4-fa4d-47a9-b9e8-c3632ac257f0)
![Safari 2023-11-27 at 16 13 00@2x](https://github.com/TheBLVD/moth.social/assets/76360/b649ffe5-1833-4349-8da6-fab882ba835c)
