### PR TITLE
MAM-3369-for-you-feed-for-rileyhbatmastodonsocial-not-updated-for-2-days

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -169,10 +169,10 @@ class Api::BaseController < ApplicationController
   # Mammoth client encoded JWT is required as Authorized Bearer header
   def require_mammoth!
     header = request.headers['Authorization']
-    header = header.split.last if header
-    raise  InvalidPayload unless header
+    @auth_header_key = header.split.last if header
+    raise InvalidPayload unless @auth_header_key
 
-    @decoded = JsonToken.decode(header)
+    @decoded = JsonToken.decode(@auth_header_key)
   end
 
   def render_empty

--- a/app/controllers/api/v4/timelines/for_you_controller.rb
+++ b/app/controllers/api/v4/timelines/for_you_controller.rb
@@ -15,7 +15,7 @@ class Api::V4::Timelines::ForYouController < Api::BaseController
   # Return Mammoth User Profile w/ foryou settings
   # api/v4/foryou/users/me/:acct
   def index
-    result = PersonalForYou.new.mammoth_user_profile(acct_param)
+    result = PersonalForYou.new.mammoth_user_profile(acct_param, @auth_header_key)
     render json: result
   end
 

--- a/app/lib/personal_for_you.rb
+++ b/app/lib/personal_for_you.rb
@@ -62,14 +62,14 @@ class PersonalForYou
   # and check for enrollment.
   # for_you_setting type can be 'public' | 'personal' | 'waitlist'
   # If Overload is enabled set status to 'overloaded'
-  def mammoth_user_profile(acct)
+  def mammoth_user_profile(acct, auth_header_key)
     user = user(acct)
     # Mammoth Overload Check set if overload is enabled
     user[:for_you_settings][:status] = 'overloaded' if MAMMOTH_OVERLOAD_ENABLE
     return user unless user[:for_you_settings][:type] == 'public'
 
     # if for_you is public get the waitlist
-    waitlist = waitlist_status(acct)
+    waitlist = waitlist_status(acct, auth_header_key)
     user[:for_you_settings][:type] = 'waitlist' if waitlist == 'enrolled'
     user
   end
@@ -97,8 +97,8 @@ class PersonalForYou
 
   # Get User Waitlist Status
   # :waitlist will be 'none' | 'enrolled'
-  def waitlist_status(acct)
-    response = HTTP.headers({ Authorization: ACCOUNT_RELAY_AUTH, 'Content-Type': 'application/json' }).get(
+  def waitlist_status(acct, auth_header_key)
+    response = HTTP.headers({ Authorization: "Bearer #{auth_header_key}", 'Content-Type': 'application/json' }).get(
       "https://#{FEATURE_HOST}/api/v1/personalize?acct=#{acct}"
     )
     JSON.parse(response.body, symbolize_names: true)[:waitlist]


### PR DESCRIPTION
* Feature.Moth.Social requires auth header for `api/personalize` http requests. Pass along that header from client to feature 

resolves [MAM-3369](https://linear.app/theblvd/issue/MAM-3387/add-featuremothsocial-auth-token-to-mothsocial-and-reable-personalize)