### PR TITLE
 MAM-3411-host-apple-app-site-association-file-also-in-well-known-folder

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,7 @@ Rails.application.routes.draw do
 
   get 'health', to: 'health#show'
   get 'apple-app-site-association', to: 'home#apple_app_site_association'
+  get '.well-known/apple-app-site-association', to: 'home#apple_app_site_association'
 
   authenticate :user, lambda { |u| u.role&.can?(:view_devops) } do
     mount Sidekiq::Web, at: 'sidekiq', as: :sidekiq
@@ -173,7 +174,6 @@ Rails.application.routes.draw do
   draw(:admin)
 
   get '/admin', to: redirect('/admin/dashboard', status: 302)
-
 
   draw(:api)
 


### PR DESCRIPTION
* Adds [apple-app-site-association](https://moth.social/apple-app-site-association) to .well-known route as well. 

Deployed to staging `https://staging.moth.social/.well-known/apple-app-site-association`