### PR TITLE
MAM-3450-private-messages-viewable-in-smart-list 

### DIFF
--- a/app/lib/mammoth/channels.rb
+++ b/app/lib/mammoth/channels.rb
@@ -42,8 +42,8 @@ module Mammoth
     end
 
     def statuses_from_channels(account_ids)
-      Status.where(account_id: account_ids,
-                   created_at: (GO_BACK.hours.ago)..Time.current)
+      Status.with_public_visibility.where(account_id: account_ids,
+                                          created_at: (GO_BACK.hours.ago)..Time.current)
     end
 
     # Check status for Channel's set level of engagment

--- a/app/lib/mammoth/curated_list.rb
+++ b/app/lib/mammoth/curated_list.rb
@@ -21,8 +21,8 @@ module Mammoth
     def statuses_from_list(account_ids)
       cache_key = 'mammoth_picks:statuses'
       Rails.cache.fetch(cache_key, expires_in: 120.seconds) do
-        statuses = Status.where(account_id: account_ids,
-                                created_at: (GO_BACK.hours.ago)..Time.current).to_a
+        statuses = Status.with_public_visibility.where(account_id: account_ids,
+                                                       created_at: (GO_BACK.hours.ago)..Time.current).to_a
 
         statuses.filter_map { |s| engagment_threshold(s) }.pluck(:id, :account_id).map { |id, account_id| { id: id, account_id: account_id } }
       end

--- a/app/lib/personal_for_you.rb
+++ b/app/lib/personal_for_you.rb
@@ -41,7 +41,7 @@ class PersonalForYou
     Rails.logger.debug { "INDIRECT FOLLOW RECOMMENDATIONS USERNAMES\n #{username_query}" }
     Rails.logger.debug { "INDIRECT FOLLOW RECOMMENDATIONS ACCOUNT_IDS\n #{account_ids}" }
     # Get Statuses for those accounts
-    Status.where(account_id: account_ids, updated_at: 12.hours.ago..Time.current).limit(200)
+    Status.with_public_visibility.where(account_id: account_ids, updated_at: 12.hours.ago..Time.current).limit(200)
   end
 
   # Get All registered users from AcctRely
@@ -156,7 +156,7 @@ class PersonalForYou
     # Array of account id's from fedi_account_handles
     account_ids = Account.where(username: username_query, domain: domain_query).pluck(:id)
     # Get Statuses for those accounts
-    Status.where(account_id: account_ids, updated_at: 12.hours.ago..Time.current).limit(200)
+    Status.with_public_visibility.where(account_id: account_ids, updated_at: 12.hours.ago..Time.current).limit(200)
   end
 
   # Get enabled channels with full accounts


### PR DESCRIPTION
* Query for statuses needs to be scoped to 'public' only. 