### PR TITLE
 MAM-3832-unsubscribe-subscribe-blocking

### DIFF
--- a/app/lib/mammoth/status_origin.rb
+++ b/app/lib/mammoth/status_origin.rb
@@ -80,16 +80,6 @@ module Mammoth
         return results
     end 
 
-    # Find items from 1000 - end of the  list
-    # Then del them
-    def trim(user)
-        user_list_key = key(user[:acct])
-        keys_to_purge = redis.zrange(user_list_key, MAX_ITEMS, -1)
-        redis.pipelined do |p|
-            p.del(keys_to_purge)
-        end
-    end 
-
 
     # Delete All Status Origins by username
     # ALERT: extra check to ensure a valid acct handle is passed.  
@@ -133,4 +123,14 @@ module Mammoth
         Oj.dump({source: "FriendsOfFriends", originating_account_id: status.account[:id] })
     end
   end
+
+    # Find items from 1000 - end of the  list
+    # Then del them
+    def trim(user)
+        user_list_key = key(user[:acct])
+        keys_to_purge = redis.zrange(user_list_key, MAX_ITEMS, -1)
+        redis.pipelined do |p|
+            p.del(keys_to_purge)
+        end
+    end 
 end

--- a/app/lib/mammoth/status_origin.rb
+++ b/app/lib/mammoth/status_origin.rb
@@ -52,7 +52,7 @@ module Mammoth
     
     def bulk_reasons(user, reasons)
         user_list_key = key(user[:acct])
-        Rails.logger.info "USER LIST KEY #{user_list_key}"
+        Rails.logger.debug "USER LIST KEY #{user_list_key}"
         redis.pipelined do |p|
             reasons.each do |r|
                 p.zadd(user_list_key, 0, r[:key])

--- a/app/lib/mammoth/status_origin.rb
+++ b/app/lib/mammoth/status_origin.rb
@@ -122,7 +122,6 @@ module Mammoth
     def trending_fof_reason(status)
         Oj.dump({source: "FriendsOfFriends", originating_account_id: status.account[:id] })
     end
-  end
 
     # Find items from 1000 - end of the  list
     # Then del them
@@ -133,4 +132,7 @@ module Mammoth
             p.del(keys_to_purge)
         end
     end 
+
+    end
+
 end

--- a/app/lib/mammoth/status_origin.rb
+++ b/app/lib/mammoth/status_origin.rb
@@ -123,7 +123,7 @@ module Mammoth
         Oj.dump({source: "FriendsOfFriends", originating_account_id: status.account[:id] })
     end
 
-    # Find items from 1000 - end of the  list
+    # Find items from MAX_ITEMS - end of the  list
     # Then del them
     def trim(user)
         user_list_key = key(user[:acct])

--- a/app/lib/mammoth/status_origin.rb
+++ b/app/lib/mammoth/status_origin.rb
@@ -9,7 +9,7 @@ module Mammoth
         include Redisable
     class NotFound < StandardError; end
 
-    MAX_ITEMS = 1000
+    MAX_ITEMS = 5000
 
     # Add Trending Follows and Reason
     def bulk_add_trending_follows(statuses, user)

--- a/app/lib/mammoth/status_origin.rb
+++ b/app/lib/mammoth/status_origin.rb
@@ -85,8 +85,13 @@ module Mammoth
         username, domain = acct.strip.gsub(/\A@/, '').split('@')
         return nil unless username && domain
 
-        list_key = key("#{username}@#{domain}")
-        redis.keys("#{list_key}*").each { |key| redis.del(key) }
+        user_list_key = key("#{username}@#{domain}")
+        keys_to_purge = redis.zrange(user_list_key, 0, -1)
+        redis.pipelined do |p|
+            p.del(keys_to_purge)
+            p.del(user_list_key)
+        end 
+
     end 
 
     private 

--- a/app/lib/personal_for_you.rb
+++ b/app/lib/personal_for_you.rb
@@ -24,7 +24,7 @@ class PersonalForYou
   def statuses_for_indirect_follows(account_handle)
     cache_key = "follow_recommendations:#{account_handle}"
     fedi_account_handles = Rails.cache.fetch(cache_key)
-    Rails.logger.info { "INDIRECT FOLLOW RECOMMENDATIONS HANDLES\n #{fedi_account_handles}" }
+    Rails.logger.debug { "INDIRECT FOLLOW RECOMMENDATIONS HANDLES\n #{fedi_account_handles}" }
     # Early return if no fedi account handles found
     return [] if fedi_account_handles.nil?
 
@@ -38,8 +38,8 @@ class PersonalForYou
     end
     # Array of account id's from fedi_account_handles
     account_ids = Account.where(username: username_query, domain: domain_query).pluck(:id)
-    Rails.logger.info { "INDIRECT FOLLOW RECOMMENDATIONS USERNAMES\n #{username_query}" }
-    Rails.logger.info { "INDIRECT FOLLOW RECOMMENDATIONS ACCOUNT_IDS\n #{account_ids}" }
+    Rails.logger.debug { "INDIRECT FOLLOW RECOMMENDATIONS USERNAMES\n #{username_query}" }
+    Rails.logger.debug { "INDIRECT FOLLOW RECOMMENDATIONS ACCOUNT_IDS\n #{account_ids}" }
     # Get Statuses for those accounts
     Status.with_public_visibility.where(account_id: account_ids, updated_at: 12.hours.ago..Time.current).limit(200)
   end
@@ -142,7 +142,7 @@ class PersonalForYou
 
   def statuses_for_direct_follows(acct)
     following = user_following(acct)
-    Rails.logger.info { "FOLLOW RECOMMENDATIONS RETURN \n #{following}" }
+    Rails.logger.debug { "FOLLOW RECOMMENDATIONS RETURN \n #{following}" }
     # Parse handles into username & domain array for batch account query
     username_query = []
     domain_query = []
@@ -152,7 +152,7 @@ class PersonalForYou
       username_query.push(user['username'])
       domain_query.push(domain)
     end
-    Rails.logger.info { "FOLLOW RECOMMENDATIONS USERNAMES \n #{username_query}" }
+    Rails.logger.debug { "FOLLOW RECOMMENDATIONS USERNAMES \n #{username_query}" }
     # Array of account id's from fedi_account_handles
     account_ids = Account.where(username: username_query, domain: domain_query).pluck(:id)
     # Get Statuses for those accounts
@@ -208,7 +208,7 @@ class PersonalForYou
   # Remove personal timeline this will remove all entries in user's personal for you feed
   # Current behavior is to default to 'public' mammoth curated feed if user's personal feed is blank 8/16/2023
   def reset_feed(username)
-    Rails.logger.info { "RESETTING THE FEED>>>>>>>>>> \n #{username} \n" }
+    Rails.logger.debug { "RESETTING THE FEED>>>>>>>>>> \n #{username} \n" }
     timeline_key = FeedManager.instance.key('personal', username)
     redis.del(timeline_key)
   end

--- a/app/lib/personal_for_you.rb
+++ b/app/lib/personal_for_you.rb
@@ -24,7 +24,7 @@ class PersonalForYou
   def statuses_for_indirect_follows(account_handle)
     cache_key = "follow_recommendations:#{account_handle}"
     fedi_account_handles = Rails.cache.fetch(cache_key)
-    Rails.logger.debug { "INDIRECT FOLLOW RECOMMENDATIONS HANDLES\n #{fedi_account_handles}" }
+    Rails.logger.info { "INDIRECT FOLLOW RECOMMENDATIONS HANDLES\n #{fedi_account_handles}" }
     # Early return if no fedi account handles found
     return [] if fedi_account_handles.nil?
 
@@ -38,8 +38,8 @@ class PersonalForYou
     end
     # Array of account id's from fedi_account_handles
     account_ids = Account.where(username: username_query, domain: domain_query).pluck(:id)
-    Rails.logger.debug { "INDIRECT FOLLOW RECOMMENDATIONS USERNAMES\n #{username_query}" }
-    Rails.logger.debug { "INDIRECT FOLLOW RECOMMENDATIONS ACCOUNT_IDS\n #{account_ids}" }
+    Rails.logger.info { "INDIRECT FOLLOW RECOMMENDATIONS USERNAMES\n #{username_query}" }
+    Rails.logger.info { "INDIRECT FOLLOW RECOMMENDATIONS ACCOUNT_IDS\n #{account_ids}" }
     # Get Statuses for those accounts
     Status.with_public_visibility.where(account_id: account_ids, updated_at: 12.hours.ago..Time.current).limit(200)
   end
@@ -142,7 +142,7 @@ class PersonalForYou
 
   def statuses_for_direct_follows(acct)
     following = user_following(acct)
-    Rails.logger.debug { "FOLLOW RECOMMENDATIONS RETURN \n #{following}" }
+    Rails.logger.info { "FOLLOW RECOMMENDATIONS RETURN \n #{following}" }
     # Parse handles into username & domain array for batch account query
     username_query = []
     domain_query = []
@@ -152,7 +152,7 @@ class PersonalForYou
       username_query.push(user['username'])
       domain_query.push(domain)
     end
-    Rails.logger.debug { "FOLLOW RECOMMENDATIONS USERNAMES \n #{username_query}" }
+    Rails.logger.info { "FOLLOW RECOMMENDATIONS USERNAMES \n #{username_query}" }
     # Array of account id's from fedi_account_handles
     account_ids = Account.where(username: username_query, domain: domain_query).pluck(:id)
     # Get Statuses for those accounts
@@ -208,7 +208,7 @@ class PersonalForYou
   # Remove personal timeline this will remove all entries in user's personal for you feed
   # Current behavior is to default to 'public' mammoth curated feed if user's personal feed is blank 8/16/2023
   def reset_feed(username)
-    Rails.logger.debug { "RESETTING THE FEED>>>>>>>>>> \n #{username} \n" }
+    Rails.logger.info { "RESETTING THE FEED>>>>>>>>>> \n #{username} \n" }
     timeline_key = FeedManager.instance.key('personal', username)
     redis.del(timeline_key)
   end


### PR DESCRIPTION
* Update breadcrumb cleanup process for rebuilding ForYou feed.
* Continually trim user's breadcrumbs during batch updates.

## Current Time to purge breadcrumbs when rebuilding
![Safari 2024-01-29 at 15 28 14@2x](https://github.com/TheBLVD/moth.social/assets/76360/38ec2014-e379-4a75-9dff-8537f95b5568)
```sh
debian@moth:~$ redis-cli slowlog get
 1) 1) (integer) 517
    2) (integer) 1706567160
    3) (integer) 1269129
    4) 1) "keys"
       2) "origin:for_you:sznowicki@pol.social*"
    5) "127.0.0.1:36766"
    6) ""
```

## New Time to purge breadcrumbs when rebuilding
I did the math,
 109x faster 
 99.2% faster
🚀 
![Safari 2024-01-29 at 15 27 03@2x](https://github.com/TheBLVD/moth.social/assets/76360/0d06634a-2c57-4450-aa62-3fb87779dc7c)
```sh
debian@vps-814f87db:~$ redis-cli SLOWLOG GET
 1) 1) (integer) 12631
    2) (integer) 1706566778
    3) (integer) 11397
    4) 1) "scan"
       2) "40963"
       3) "MATCH"
       4) "*origin:for_you:jtomchak@staging.moth.social*"
       5) "COUNT"
       6) "10000"
    5) "127.0.0.1:40024"
    6) ""
```

