### PR TITLE
Disable AppSignal

### DIFF
--- a/config/appsignal.yml
+++ b/config/appsignal.yml
@@ -45,14 +45,14 @@ ignore_errors:
 
 development:
   <<: *defaults
-  active: true
+  active: false
 
 production:
   <<: *defaults
-  active: true
-  enable_nginx_metrics: true
+  active: false
+  enable_nginx_metrics: false
 
 staging:
   <<: *defaults
-  active: true
-  enable_nginx_metrics: true
+  active: false
+  enable_nginx_metrics: false


### PR DESCRIPTION
Disables app specific metrics to AppSignal. Server metrics are still being sent by Statsd. (see image)
![Safari 2024-03-07 at 14 27 24@2x](https://github.com/TheBLVD/moth.social/assets/76360/5975c4a2-4389-42a0-b56d-4707780af4de)

![Safari 2024-03-07 at 14 30 09@2x](https://github.com/TheBLVD/moth.social/assets/76360/741125a3-52f8-4f92-8c14-54112065976d)

